### PR TITLE
Support jsx on @rediagram/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@rediagram/aws": "^0.2.0",
+    "@rediagram/tsconfig": "^0.0.0",
     "@ts-graphviz/react": "^0.7.0",
     "@types/node": "^14.0.4",
     "@types/prop-types": "^15.7.3",

--- a/packages/cli/src/rediagramc.ts
+++ b/packages/cli/src/rediagramc.ts
@@ -4,13 +4,14 @@ import { register } from 'ts-node';
 import path from 'path';
 import { version } from './pkg';
 
-register();
-
 cmd
   .name('rediagramc')
   .version(version)
   .arguments('[pattarns...]')
   .action(async function rediagram(pattarns: string[]): Promise<void> {
+    register({
+      project: require.resolve('@rediagram/tsconfig/tsconfig.json'),
+    });
     const sources = glob.sync([...pattarns, '**/*.rediagram.{jsx,tsx}', '!**/node_modules/**/*'], {
       dot: true,
       extglob: true,

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,0 +1,40 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
+
+### A base TSConfig for working with rediagram
+
+Add the package to your `"devDependencies"`:
+
+```sh
+$ npm install --save-dev @rediagram/tsconfig
+# or yarn
+$ yarn add --dev @rediagram/tsconfig
+```
+
+Add to your `tsconfig.json`:
+
+```json
+"extends": "@rediagram/tsconfig/tsconfig.json"
+```
+
+---
+
+The `tsconfig.json`:
+
+```jsonc
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "rediagram",
+  "compilerOptions": {
+    "jsx": "react",
+    "lib": [],
+    "resolveJsonModule": true,
+    "strict": true
+  }
+}
+```
+
+## License
+
+This software is released under the MIT License, see LICENSE.

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.0.0",
+  "license": "MIT",
+  "name": "@rediagram/tsconfig",
+  "author": "kamiazya <yuki@kamiazya.tech>",
+  "description": "A base TSConfig for working with rediagram.",
+  "homepage": "https://github.com/kamiazya/rediagram",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kamiazya/rediagram.git",
+    "directory": "packages/tsconfig"
+  },
+  "bugs": {
+    "url": "https://github.com/kamiazya/rediagram/issues"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/kamiazya"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "rediagram",
+  "compilerOptions": {
+    "jsx": "react",
+    "strict": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "lib": [
+      "esnext"
+    ],
+    "allowJs": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
Specified `allowJs: true` tsconfig which is the base when registering ts-node with redigramc.

I also packaged the tsconfig as `@redigram/tsconfig`.

close #6
