### PR TITLE
Add display service name option

### DIFF
--- a/component-libraries/aws/src/components/analytics/Analytics.tsx
+++ b/component-libraries/aws/src/components/analytics/Analytics.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AnalyticsProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Analytics');
+  }
+  return undefined;
+}
+
 export const Analytics: FC<AnalyticsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Analytics.displayName = 'Analytics';

--- a/component-libraries/aws/src/components/analytics/Athena.tsx
+++ b/component-libraries/aws/src/components/analytics/Athena.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AthenaProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Athena');
+      default:
+        return SubLabel('Athena');
+    }
+  }
+  return undefined;
+}
+
 export const Athena: FC<AthenaProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Athena.displayName = 'Athena';

--- a/component-libraries/aws/src/components/analytics/CloudSearch.tsx
+++ b/component-libraries/aws/src/components/analytics/CloudSearch.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudSearchType = 'Search documents';
 
@@ -29,11 +31,26 @@ function useIcon(type?: CloudSearchType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon CloudSearch');
+      default:
+        return SubLabel('CloudSearch');
+    }
+  }
+  return undefined;
+}
+
 export const CloudSearch: FC<CloudSearchProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CloudSearch.displayName = 'CloudSearch';

--- a/component-libraries/aws/src/components/analytics/DataPipeline.tsx
+++ b/component-libraries/aws/src/components/analytics/DataPipeline.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DataPipelineProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Data Pipeline');
+      default:
+        return SubLabel('Data Pipeline');
+    }
+  }
+  return undefined;
+}
+
 export const DataPipeline: FC<DataPipelineProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DataPipeline.displayName = 'DataPipeline';

--- a/component-libraries/aws/src/components/analytics/EMR.tsx
+++ b/component-libraries/aws/src/components/analytics/EMR.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type EMRType =
   | 'HDFS cluster'
@@ -45,11 +47,26 @@ function useIcon(type?: EMRType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon EMR');
+      default:
+        return SubLabel('EMR');
+    }
+  }
+  return undefined;
+}
+
 export const EMR: FC<EMRProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 EMR.displayName = 'EMR';

--- a/component-libraries/aws/src/components/analytics/ElasticsearchService.tsx
+++ b/component-libraries/aws/src/components/analytics/ElasticsearchService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElasticsearchServiceProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elasticsearch Service');
+      default:
+        return SubLabel('Elasticsearch Service');
+    }
+  }
+  return undefined;
+}
+
 export const ElasticsearchService: FC<ElasticsearchServiceProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElasticsearchService.displayName = 'ElasticsearchService';

--- a/component-libraries/aws/src/components/analytics/Glue.tsx
+++ b/component-libraries/aws/src/components/analytics/Glue.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type GlueType = 'Crawler' | 'Data catalog';
 
@@ -31,11 +33,26 @@ function useIcon(type?: GlueType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Glue');
+      default:
+        return SubLabel('Glue');
+    }
+  }
+  return undefined;
+}
+
 export const Glue: FC<GlueProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Glue.displayName = 'Glue';

--- a/component-libraries/aws/src/components/analytics/Kinesis.tsx
+++ b/component-libraries/aws/src/components/analytics/Kinesis.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type KinesisType = 'Video Streams' | 'Data Streams' | 'Data Firehose' | 'Data Analytics';
 
@@ -35,11 +37,26 @@ function useIcon(type?: KinesisType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Kinesis');
+      default:
+        return SubLabel('Kinesis');
+    }
+  }
+  return undefined;
+}
+
 export const Kinesis: FC<KinesisProps> = ({ name, type, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Kinesis.displayName = 'Kinesis';

--- a/component-libraries/aws/src/components/analytics/LakeFormation.tsx
+++ b/component-libraries/aws/src/components/analytics/LakeFormation.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type LakeFormationType = 'Data lake';
 
@@ -29,11 +31,26 @@ function useIcon(type?: LakeFormationType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Lake Formation');
+      default:
+        return SubLabel('Lake Formation');
+    }
+  }
+  return undefined;
+}
+
 export const LakeFormation: FC<LakeFormationProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 LakeFormation.displayName = 'LakeFormation';

--- a/component-libraries/aws/src/components/analytics/ManagedStreamingForKafka.tsx
+++ b/component-libraries/aws/src/components/analytics/ManagedStreamingForKafka.tsx
@@ -1,7 +1,9 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, HasDependences, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ManagedStreamingForKafkaProps = {
   name: string;
@@ -20,11 +22,28 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Managed Streaming for Apache Kafka');
+      case 'medium':
+        return SubLabel('Managed Streaming for Apache Kafka');
+      default:
+        return SubLabel('Apache Kafka');
+    }
+  }
+  return undefined;
+}
+
 export const ManagedStreamingForKafka: FC<ManagedStreamingForKafkaProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ManagedStreamingForKafka.displayName = 'ManagedStreamingForKafka';

--- a/component-libraries/aws/src/components/analytics/QuickSight.tsx
+++ b/component-libraries/aws/src/components/analytics/QuickSight.tsx
@@ -1,7 +1,9 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, HasDependences, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type QuickSightProps = {
   name: string;
@@ -20,11 +22,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon QuickSight');
+      default:
+        return SubLabel('QuickSight');
+    }
+  }
+  return undefined;
+}
+
 export const QuickSight: FC<QuickSightProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 QuickSight.displayName = 'QuickSight';

--- a/component-libraries/aws/src/components/application-integration/ApplicationIntegration.tsx
+++ b/component-libraries/aws/src/components/application-integration/ApplicationIntegration.tsx
@@ -1,7 +1,9 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, HasDependences, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ApplicationIntegrationProps = {
   name: string;
@@ -20,11 +22,19 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Application Integration');
+  }
+  return undefined;
+}
 export const ApplicationIntegration: FC<ApplicationIntegrationProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ApplicationIntegration.displayName = 'ApplicationIntegration';

--- a/component-libraries/aws/src/components/application-integration/ConsoleMobileApplication.tsx
+++ b/component-libraries/aws/src/components/application-integration/ConsoleMobileApplication.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ConsoleMobileApplicationProps = {
   name: string;
@@ -21,11 +23,25 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Console Mobile Application');
+      default:
+        return SubLabel('Console Mobile Application');
+    }
+  }
+  return undefined;
+}
 export const ConsoleMobileApplication: FC<ConsoleMobileApplicationProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ConsoleMobileApplication.displayName = 'ConsoleMobileApplication';

--- a/component-libraries/aws/src/components/application-integration/EventBridge.tsx
+++ b/component-libraries/aws/src/components/application-integration/EventBridge.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useMemo, ReactElement } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { SubLabel } from '../../hooks/service-name';
+import { useAWSContext } from '../../hooks/context';
 
 export type EventBridgeType = 'Event' | 'Default' | 'Custom' | 'SaaS';
 
@@ -35,11 +37,25 @@ function useIcon(type?: EventBridgeType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon EventBridge');
+      default:
+        return SubLabel('EventBridge');
+    }
+  }
+  return undefined;
+}
 export const EventBridge: FC<EventBridgeProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 EventBridge.displayName = 'EventBridge';

--- a/component-libraries/aws/src/components/application-integration/ExpressWorkflows.tsx
+++ b/component-libraries/aws/src/components/application-integration/ExpressWorkflows.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ExpressWorkflowsProps = {
   name: string;
@@ -20,12 +22,19 @@ function useIcon(): { path: string; size: number } {
     };
   }, []);
 }
-
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Express Workflows');
+  }
+  return undefined;
+}
 export const ExpressWorkflows: FC<ExpressWorkflowsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ExpressWorkflows.displayName = 'ExpressWorkflows';

--- a/component-libraries/aws/src/components/application-integration/MQ.tsx
+++ b/component-libraries/aws/src/components/application-integration/MQ.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type MQProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon MQ');
+      default:
+        return SubLabel('MQ');
+    }
+  }
+  return undefined;
+}
+
 export const MQ: FC<MQProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 MQ.displayName = 'MQ';

--- a/component-libraries/aws/src/components/application-integration/SimpleNotificationService.tsx
+++ b/component-libraries/aws/src/components/application-integration/SimpleNotificationService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SimpleNotificationServiceType = 'Email notification' | 'HTTP notification' | 'Topic';
 
@@ -33,6 +35,22 @@ function useIcon(type?: SimpleNotificationServiceType): { path: string; size: nu
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Simple Notification Service');
+      case 'medium':
+        return SubLabel('Simple Notification Service');
+      default:
+        return SubLabel('SNS');
+    }
+  }
+  return undefined;
+}
+
 export const SimpleNotificationService: FC<SimpleNotificationServiceProps> = ({
   type,
   name,
@@ -42,7 +60,10 @@ export const SimpleNotificationService: FC<SimpleNotificationServiceProps> = ({
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SimpleNotificationService.displayName = 'SimpleNotificationService';
+
+export const SNS = SimpleNotificationService;

--- a/component-libraries/aws/src/components/application-integration/SimpleQueueService.tsx
+++ b/component-libraries/aws/src/components/application-integration/SimpleQueueService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SimpleQueueServiceType = 'Message' | 'Queue';
 
@@ -31,11 +33,30 @@ function useIcon(type?: SimpleQueueServiceType): { path: string; size: number } 
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Simple Queue Service');
+      case 'medium':
+        return SubLabel('Simple Queue Service');
+      default:
+        return SubLabel('SQS');
+    }
+  }
+  return undefined;
+}
+
 export const SimpleQueueService: FC<SimpleQueueServiceProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SimpleQueueService.displayName = 'SimpleQueueService';
+
+export const SQS = SimpleQueueService;

--- a/component-libraries/aws/src/components/application-integration/StepFunctions.tsx
+++ b/component-libraries/aws/src/components/application-integration/StepFunctions.tsx
@@ -1,7 +1,9 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, HasDependences, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type StepFunctionsProps = {
   name: string;
@@ -20,11 +22,28 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Step Functions');
+      default:
+        return SubLabel('Step Functions');
+    }
+  }
+  return undefined;
+}
+
 export const StepFunctions: FC<StepFunctionsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 StepFunctions.displayName = 'StepFunctions';
+
+export const SF = StepFunctions;

--- a/component-libraries/aws/src/components/ar-vr/ArVr.tsx
+++ b/component-libraries/aws/src/components/ar-vr/ArVr.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ArVrProps = {
   name: string;
@@ -21,11 +23,21 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('VR & AR');
+  }
+  return undefined;
+}
 export const ArVr: FC<ArVrProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ArVr.displayName = 'ArVr';
+
+export const VrAr = ArVr;

--- a/component-libraries/aws/src/components/ar-vr/Sumerian.tsx
+++ b/component-libraries/aws/src/components/ar-vr/Sumerian.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SumerianProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Sumerian');
+      default:
+        return SubLabel('Sumerian');
+    }
+  }
+  return undefined;
+}
+
 export const Sumerian: FC<SumerianProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Sumerian.displayName = 'Sumerian';

--- a/component-libraries/aws/src/components/blockchain/Blockchain.tsx
+++ b/component-libraries/aws/src/components/blockchain/Blockchain.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type BlockchainProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Blockchain');
+  }
+  return undefined;
+}
+
 export const Blockchain: FC<BlockchainProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Blockchain.displayName = 'Blockchain';

--- a/component-libraries/aws/src/components/blockchain/ManagedBlockchain.tsx
+++ b/component-libraries/aws/src/components/blockchain/ManagedBlockchain.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ManagedBlockchainType = 'Blockchain';
 
@@ -29,11 +31,26 @@ function useIcon(type?: ManagedBlockchainType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Managed Blockchain');
+      default:
+        return SubLabel('Managed Blockchain');
+    }
+  }
+  return undefined;
+}
+
 export const ManagedBlockchain: FC<ManagedBlockchainProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ManagedBlockchain.displayName = 'ManagedBlockchain';

--- a/component-libraries/aws/src/components/business-applications/AlexaForBusiness.tsx
+++ b/component-libraries/aws/src/components/business-applications/AlexaForBusiness.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AlexaForBusinessProps = {
   name: string;
@@ -21,11 +23,19 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Alexa for Business');
+  }
+  return undefined;
+}
 export const AlexaForBusiness: FC<AlexaForBusinessProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 AlexaForBusiness.displayName = 'AlexaForBusiness';

--- a/component-libraries/aws/src/components/business-applications/BusinessApplications.tsx
+++ b/component-libraries/aws/src/components/business-applications/BusinessApplications.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type BusinessApplicationsProps = {
   name: string;
@@ -21,11 +23,19 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Business Applications');
+  }
+  return undefined;
+}
 export const BusinessApplications: FC<BusinessApplicationsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 BusinessApplications.displayName = 'BusinessApplications';

--- a/component-libraries/aws/src/components/business-applications/Chime.tsx
+++ b/component-libraries/aws/src/components/business-applications/Chime.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ChimeProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Chime');
+      default:
+        return SubLabel('Chime');
+    }
+  }
+  return undefined;
+}
+
 export const Chime: FC<ChimeProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Chime.displayName = 'Chime';

--- a/component-libraries/aws/src/components/business-applications/WorkMail.tsx
+++ b/component-libraries/aws/src/components/business-applications/WorkMail.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type WorkMailProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon WorkMail');
+      default:
+        return SubLabel('WorkMail');
+    }
+  }
+  return undefined;
+}
+
 export const WorkMail: FC<WorkMailProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 WorkMail.displayName = 'WorkMail';

--- a/component-libraries/aws/src/components/compute/Batch.tsx
+++ b/component-libraries/aws/src/components/compute/Batch.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type BatchProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Batch');
+      default:
+        return SubLabel('Batch');
+    }
+  }
+  return undefined;
+}
+
 export const Batch: FC<BatchProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Batch.displayName = 'Batch';

--- a/component-libraries/aws/src/components/compute/Bottlerocket.tsx
+++ b/component-libraries/aws/src/components/compute/Bottlerocket.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type BottlerocketProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Bottlerocket');
+  }
+  return undefined;
+}
+
 export const Bottlerocket: FC<BottlerocketProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Bottlerocket.displayName = 'Bottlerocket';

--- a/component-libraries/aws/src/components/compute/Compute.tsx
+++ b/component-libraries/aws/src/components/compute/Compute.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { resolveAsset } from '../../assets';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ComputeProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Compute');
+  }
+  return undefined;
+}
+
 export const Compute: FC<ComputeProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Compute.displayName = 'Compute';

--- a/component-libraries/aws/src/components/compute/ComputeOptimizer.tsx
+++ b/component-libraries/aws/src/components/compute/ComputeOptimizer.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ComputeOptimizerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Compute Optimizer');
+      default:
+        return SubLabel('Compute Optimizer');
+    }
+  }
+  return undefined;
+}
+
 export const ComputeOptimizer: FC<ComputeOptimizerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ComputeOptimizer.displayName = 'ComputeOptimizer';

--- a/component-libraries/aws/src/components/compute/ContainerRegistry.tsx
+++ b/component-libraries/aws/src/components/compute/ContainerRegistry.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ContainerRegistryType = 'Registry' | 'Image';
 
@@ -31,11 +33,30 @@ function useIcon(type?: ContainerRegistryType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Elastic Container Registry');
+      case 'medium':
+        return SubLabel('Elastic Container Registry');
+      default:
+        return SubLabel('ECR');
+    }
+  }
+  return undefined;
+}
+
 export const ContainerRegistry: FC<ContainerRegistryProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ContainerRegistry.displayName = 'ContainerRegistry';
+
+export const ECR = ContainerRegistry;

--- a/component-libraries/aws/src/components/compute/ContainerService.tsx
+++ b/component-libraries/aws/src/components/compute/ContainerService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ContainerServiceType = 'Container1' | 'Container2' | 'Container3' | 'Service' | 'Task';
 
@@ -37,11 +39,29 @@ function useIcon(type?: ContainerServiceType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Elastic Container Service');
+      case 'medium':
+        return SubLabel('Elastic Container Service');
+      default:
+        return SubLabel('ECS');
+    }
+  }
+  return undefined;
+}
 export const ContainerService: FC<ContainerServiceProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ContainerService.displayName = 'ContainerService';
+
+export const ECS = ContainerService;

--- a/component-libraries/aws/src/components/compute/EC2.tsx
+++ b/component-libraries/aws/src/components/compute/EC2.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type EC2Type =
   | 'AMI'
@@ -123,11 +125,28 @@ export type EC2Props = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Elastic Compute Cloud');
+      case 'medium':
+        return SubLabel('Elastic Compute Cloud');
+      default:
+        return SubLabel('EC2');
+    }
+  }
+  return undefined;
+}
+
 export const EC2: FC<EC2Props> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 EC2.displayName = 'EC2';

--- a/component-libraries/aws/src/components/compute/ElasticBeanstalk.tsx
+++ b/component-libraries/aws/src/components/compute/ElasticBeanstalk.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElasticBeanstalkType = 'Deployment' | 'Application';
 
@@ -30,12 +32,25 @@ function useIcon(type?: ElasticBeanstalkType): { path: string; size: number } {
     };
   }, [type]);
 }
-
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elastic Beanstalk');
+      default:
+        return SubLabel('Elastic Beanstalk');
+    }
+  }
+  return undefined;
+}
 export const ElasticBeanstalk: FC<ElasticBeanstalkProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElasticBeanstalk.displayName = 'ElasticBeanstalk';

--- a/component-libraries/aws/src/components/compute/ElasticKubernetesService.tsx
+++ b/component-libraries/aws/src/components/compute/ElasticKubernetesService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElasticKubernetesServiceProps = {
   name: string;
@@ -21,11 +23,30 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Elastic Kubernetes Service');
+      case 'medium':
+        return SubLabel('Elastic Kubernetes Service');
+      default:
+        return SubLabel('EKS');
+    }
+  }
+  return undefined;
+}
+
 export const ElasticKubernetesService: FC<ElasticKubernetesServiceProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElasticKubernetesService.displayName = 'ElasticKubernetesService';
+
+export const EKS = ElasticKubernetesService;

--- a/component-libraries/aws/src/components/compute/Fargate.tsx
+++ b/component-libraries/aws/src/components/compute/Fargate.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type FargateProps = {
   name: string;
@@ -21,11 +23,25 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Fargate');
+      default:
+        return SubLabel('Fargate');
+    }
+  }
+  return undefined;
+}
 export const Fargate: FC<FargateProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Fargate.displayName = 'Fargate';

--- a/component-libraries/aws/src/components/compute/ImageBuilder.tsx
+++ b/component-libraries/aws/src/components/compute/ImageBuilder.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ImageBuilderProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('EC2 Image Builder');
+      default:
+        return SubLabel('Image Builder');
+    }
+  }
+  return undefined;
+}
+
 export const ImageBuilder: FC<ImageBuilderProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ImageBuilder.displayName = 'ImageBuilder';

--- a/component-libraries/aws/src/components/compute/Lambda.tsx
+++ b/component-libraries/aws/src/components/compute/Lambda.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type LambdaType = 'Lambda Function';
 
@@ -28,12 +30,26 @@ function useIcon(type?: LambdaType): { path: string; size: number } {
     };
   }, [type]);
 }
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Lambda');
+      default:
+        return SubLabel('Lambda');
+    }
+  }
+  return undefined;
+}
 
 export const Lambda: FC<LambdaProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Lambda.displayName = 'Lambda';

--- a/component-libraries/aws/src/components/compute/Lightsail.tsx
+++ b/component-libraries/aws/src/components/compute/Lightsail.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type LightsailProps = {
   name: string;
@@ -21,11 +23,25 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Lightsail');
+      default:
+        return SubLabel('Lightsail');
+    }
+  }
+  return undefined;
+}
 export const Lightsail: FC<LightsailProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Lightsail.displayName = 'Lightsail';

--- a/component-libraries/aws/src/components/compute/LocalZones.tsx
+++ b/component-libraries/aws/src/components/compute/LocalZones.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type LocalZonesProps = {
   name: string;
@@ -20,12 +22,25 @@ function useIcon(): { path: string; size: number } {
     };
   }, []);
 }
-
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Local Zones');
+      default:
+        return SubLabel('Local Zones');
+    }
+  }
+  return undefined;
+}
 export const LocalZones: FC<LocalZonesProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 LocalZones.displayName = 'LocalZones';

--- a/component-libraries/aws/src/components/compute/Outposts.tsx
+++ b/component-libraries/aws/src/components/compute/Outposts.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type OutpostsProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Outposts');
+      default:
+        return SubLabel('Outposts');
+    }
+  }
+  return undefined;
+}
+
 export const Outposts: FC<OutpostsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Outposts.displayName = 'Outposts';

--- a/component-libraries/aws/src/components/compute/ParallelCluster.tsx
+++ b/component-libraries/aws/src/components/compute/ParallelCluster.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ParallelClusterProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS ParallelCluster');
+      default:
+        return SubLabel('ParallelCluster');
+    }
+  }
+  return undefined;
+}
+
 export const ParallelCluster: FC<ParallelClusterProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ParallelCluster.displayName = 'ParallelCluster';

--- a/component-libraries/aws/src/components/compute/ServerlessApplicationRepository.tsx
+++ b/component-libraries/aws/src/components/compute/ServerlessApplicationRepository.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ServerlessApplicationRepositoryProps = {
   name: string;
@@ -21,6 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Serverless Application Repository');
+      default:
+        return SubLabel('Serverless Application Repository');
+    }
+  }
+  return undefined;
+}
+
 export const ServerlessApplicationRepository: FC<ServerlessApplicationRepositoryProps> = ({
   name,
   children,
@@ -29,7 +45,8 @@ export const ServerlessApplicationRepository: FC<ServerlessApplicationRepository
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ServerlessApplicationRepository.displayName = 'ServerlessApplicationRepository';

--- a/component-libraries/aws/src/components/compute/Thinkbox.tsx
+++ b/component-libraries/aws/src/components/compute/Thinkbox.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 type ThinkboxType = 'Deadline' | 'Frost' | 'Krakatoa' | 'Sequoia' | 'Stoke' | 'Mesh';
 
@@ -38,11 +40,26 @@ function useIcon(type: ThinkboxType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Thinkbox');
+      default:
+        return SubLabel('Thinkbox');
+    }
+  }
+  return undefined;
+}
+
 export const Thinkbox: FC<ThinkboxProps> = ({ name, type, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Thinkbox.displayName = 'Thinkbox';

--- a/component-libraries/aws/src/components/compute/ThinkboxKrakatoa.tsx
+++ b/component-libraries/aws/src/components/compute/ThinkboxKrakatoa.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ThinkboxKrakatoaProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Thinkbox Krakatoa');
+      default:
+        return SubLabel('Thinkbox Krakatoa');
+    }
+  }
+  return undefined;
+}
+
 export const ThinkboxKrakatoa: FC<ThinkboxKrakatoaProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ThinkboxKrakatoa.displayName = 'ThinkboxKrakatoa';

--- a/component-libraries/aws/src/components/compute/ThinkboxSequoia.tsx
+++ b/component-libraries/aws/src/components/compute/ThinkboxSequoia.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ThinkboxSequoiaProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Thinkbox Sequoia');
+      default:
+        return SubLabel('Thinkbox Sequoia');
+    }
+  }
+  return undefined;
+}
+
 export const ThinkboxSequoia: FC<ThinkboxSequoiaProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ThinkboxSequoia.displayName = 'ThinkboxSequoia';

--- a/component-libraries/aws/src/components/compute/ThinkboxStoke.tsx
+++ b/component-libraries/aws/src/components/compute/ThinkboxStoke.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ThinkboxStokeProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Thinkbox Stoke');
+      default:
+        return SubLabel('Thinkbox Stoke');
+    }
+  }
+  return undefined;
+}
+
 export const ThinkboxStoke: FC<ThinkboxStokeProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ThinkboxStoke.displayName = 'ThinkboxStoke';

--- a/component-libraries/aws/src/components/compute/ThinkboxXMesh.tsx
+++ b/component-libraries/aws/src/components/compute/ThinkboxXMesh.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ThinkboxXMeshProps = {
   name: string;
@@ -21,11 +23,25 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Thinkbox XMesh');
+      default:
+        return SubLabel('Thinkbox XMesh');
+    }
+  }
+  return undefined;
+}
 export const ThinkboxXMesh: FC<ThinkboxXMeshProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ThinkboxXMesh.displayName = 'ThinkboxXMesh';

--- a/component-libraries/aws/src/components/compute/VMwareCloudOnAWS.tsx
+++ b/component-libraries/aws/src/components/compute/VMwareCloudOnAWS.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type VMwareCloudOnAWSProps = {
   name: string;
@@ -21,11 +23,19 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('VMware Cloud on AWS');
+  }
+  return undefined;
+}
 export const VMwareCloudOnAWS: FC<VMwareCloudOnAWSProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 VMwareCloudOnAWS.displayName = 'VMwareCloudOnAWS';

--- a/component-libraries/aws/src/components/compute/Wavelength.tsx
+++ b/component-libraries/aws/src/components/compute/Wavelength.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type WavelengthProps = {
   name: string;
@@ -21,11 +23,25 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Wavelength');
+      default:
+        return SubLabel('Wavelength');
+    }
+  }
+  return undefined;
+}
 export const Wavelength: FC<WavelengthProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Wavelength.displayName = 'Wavelength';

--- a/component-libraries/aws/src/components/cost-management/Budgets.tsx
+++ b/component-libraries/aws/src/components/cost-management/Budgets.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type BudgetsProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Budgets');
+      default:
+        return SubLabel('Budgets');
+    }
+  }
+  return undefined;
+}
+
 export const Budgets: FC<BudgetsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Budgets.displayName = 'Budgets';

--- a/component-libraries/aws/src/components/cost-management/CostAndUsageReport.tsx
+++ b/component-libraries/aws/src/components/cost-management/CostAndUsageReport.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CostAndUsageReportProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Cost & Usage Report');
+      default:
+        return SubLabel('Cost & Usage Report');
+    }
+  }
+  return undefined;
+}
+
 export const CostAndUsageReport: FC<CostAndUsageReportProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CostAndUsageReport.displayName = 'CostAndUsageReport';

--- a/component-libraries/aws/src/components/cost-management/CostExplorer.tsx
+++ b/component-libraries/aws/src/components/cost-management/CostExplorer.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CostExplorerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Cost Explorer');
+      default:
+        return SubLabel('Cost Explorer');
+    }
+  }
+  return undefined;
+}
+
 export const CostExplorer: FC<CostExplorerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CostExplorer.displayName = 'CostExplorer';

--- a/component-libraries/aws/src/components/cost-management/CostManagement.tsx
+++ b/component-libraries/aws/src/components/cost-management/CostManagement.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CostManagementProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Cost Management');
+  }
+  return undefined;
+}
+
 export const CostManagement: FC<CostManagementProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CostManagement.displayName = 'CostManagement';

--- a/component-libraries/aws/src/components/cost-management/ReservedInstanceReporting.tsx
+++ b/component-libraries/aws/src/components/cost-management/ReservedInstanceReporting.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ReservedInstanceReportingProps = {
   name: string;
@@ -21,11 +23,28 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Reserved Instance (RI) Reporting');
+      case 'medium':
+        return SubLabel('Reserved Instance Reporting');
+      default:
+        return SubLabel('RI Reporting');
+    }
+  }
+  return undefined;
+}
+
 export const ReservedInstanceReporting: FC<ReservedInstanceReportingProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ReservedInstanceReporting.displayName = 'ReservedInstanceReporting';

--- a/component-libraries/aws/src/components/cost-management/SavingsPlans.tsx
+++ b/component-libraries/aws/src/components/cost-management/SavingsPlans.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SavingsPlansProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Savings Plans');
+  }
+  return undefined;
+}
+
 export const SavingsPlans: FC<SavingsPlansProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SavingsPlans.displayName = 'SavingsPlans';

--- a/component-libraries/aws/src/components/customer-enablement/CustomerEnablement.tsx
+++ b/component-libraries/aws/src/components/customer-enablement/CustomerEnablement.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CustomerEnablementProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Customer Enablement');
+      default:
+        return SubLabel('Customer Enablement');
+    }
+  }
+  return undefined;
+}
+
 export const CustomerEnablement: FC<CustomerEnablementProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CustomerEnablement.displayName = 'CustomerEnablement';

--- a/component-libraries/aws/src/components/customer-enablement/IQ.tsx
+++ b/component-libraries/aws/src/components/customer-enablement/IQ.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IQProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IQ');
+      default:
+        return SubLabel('IQ');
+    }
+  }
+  return undefined;
+}
+
 export const IQ: FC<IQProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IQ.displayName = 'IQ';

--- a/component-libraries/aws/src/components/customer-enablement/ProfessionalServices.tsx
+++ b/component-libraries/aws/src/components/customer-enablement/ProfessionalServices.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ProfessionalServicesProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Professional Services');
+      default:
+        return SubLabel('Professional Services');
+    }
+  }
+  return undefined;
+}
+
 export const ProfessionalServices: FC<ProfessionalServicesProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ProfessionalServices.displayName = 'ProfessionalServices';

--- a/component-libraries/aws/src/components/customer-enablement/Support.tsx
+++ b/component-libraries/aws/src/components/customer-enablement/Support.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SupportProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Support');
+      default:
+        return SubLabel('Support');
+    }
+  }
+  return undefined;
+}
+
 export const Support: FC<SupportProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Support.displayName = 'Support';

--- a/component-libraries/aws/src/components/customer-engagement/Connect.tsx
+++ b/component-libraries/aws/src/components/customer-engagement/Connect.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ConnectProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Connect');
+      default:
+        return SubLabel('Connect');
+    }
+  }
+  return undefined;
+}
+
 export const Connect: FC<ConnectProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Connect.displayName = 'Connect';

--- a/component-libraries/aws/src/components/customer-engagement/CustomerEngagement.tsx
+++ b/component-libraries/aws/src/components/customer-engagement/CustomerEngagement.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CustomerEngagementProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Customer Engagement');
+  }
+  return undefined;
+}
+
 export const CustomerEngagement: FC<CustomerEngagementProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CustomerEngagement.displayName = 'CustomerEngagement';

--- a/component-libraries/aws/src/components/customer-engagement/SimpleEmailService.tsx
+++ b/component-libraries/aws/src/components/customer-engagement/SimpleEmailService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SimpleEmailServiceType = 'Email';
 
@@ -29,11 +31,30 @@ function useIcon(type?: SimpleEmailServiceType): { path: string; size: number } 
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Simple Email Service');
+      case 'medium':
+        return SubLabel('Simple Email Service');
+      default:
+        return SubLabel('SES');
+    }
+  }
+  return undefined;
+}
+
 export const SimpleEmailService: FC<SimpleEmailServiceProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SimpleEmailService.displayName = 'SimpleEmailService';
+
+export const SES = SimpleEmailService;

--- a/component-libraries/aws/src/components/database/Aurora.tsx
+++ b/component-libraries/aws/src/components/database/Aurora.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AuroraProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Aurora');
+      default:
+        return SubLabel('Aurora');
+    }
+  }
+  return undefined;
+}
+
 export const Aurora: FC<AuroraProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Aurora.displayName = 'Aurora';

--- a/component-libraries/aws/src/components/database/Database.tsx
+++ b/component-libraries/aws/src/components/database/Database.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DatabaseProps = {
   name: string;
@@ -20,12 +22,20 @@ function useIcon(): { path: string; size: number } {
     };
   }, []);
 }
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Database');
+  }
+  return undefined;
+}
 
 export const Database: FC<DatabaseProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Database.displayName = 'Database';

--- a/component-libraries/aws/src/components/database/DatabaseMigrationService.tsx
+++ b/component-libraries/aws/src/components/database/DatabaseMigrationService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 type DatabaseMigrationServiceCategory = 'database' | 'migration-transfer';
 
@@ -35,6 +37,22 @@ export type DatabaseMigrationServiceProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Database Migration Service');
+      case 'medium':
+        return SubLabel('Database Migration Service');
+      default:
+        return SubLabel('Aurora');
+    }
+  }
+  return undefined;
+}
+
 export const DatabaseMigrationService: FC<DatabaseMigrationServiceProps> = ({
   category = 'database',
   type,
@@ -45,7 +63,8 @@ export const DatabaseMigrationService: FC<DatabaseMigrationServiceProps> = ({
   useAssertProvider();
   const icon = useIcon(category, type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DatabaseMigrationService.displayName = 'DatabaseMigrationService';

--- a/component-libraries/aws/src/components/database/DocumentDB.tsx
+++ b/component-libraries/aws/src/components/database/DocumentDB.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DocumentDBProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon DocumentDB');
+      default:
+        return SubLabel('DocumentDB');
+    }
+  }
+  return undefined;
+}
+
 export const DocumentDB: FC<DocumentDBProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DocumentDB.displayName = 'DocumentDB';

--- a/component-libraries/aws/src/components/database/DynamoDB.tsx
+++ b/component-libraries/aws/src/components/database/DynamoDB.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DynamoDBType = 'Attribute' | 'Items' | 'Item' | 'Table' | 'Attributes' | 'Global secondary index' | 'DAX';
 
@@ -41,11 +43,26 @@ export type DynamoDBProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon DynamoDB');
+      default:
+        return SubLabel('DynamoDB');
+    }
+  }
+  return undefined;
+}
+
 export const DynamoDB: FC<DynamoDBProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DynamoDB.displayName = 'DynamoDB';

--- a/component-libraries/aws/src/components/database/ElastiCache.tsx
+++ b/component-libraries/aws/src/components/database/ElastiCache.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElastiCacheType = 'Cache node' | 'Redis' | 'Memcached';
 
@@ -33,11 +35,26 @@ export type ElastiCacheProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon ElastiCache');
+      default:
+        return SubLabel('ElastiCache');
+    }
+  }
+  return undefined;
+}
+
 export const ElastiCache: FC<ElastiCacheProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElastiCache.displayName = 'ElastiCache';

--- a/component-libraries/aws/src/components/database/ManagedApacheCassandraService.tsx
+++ b/component-libraries/aws/src/components/database/ManagedApacheCassandraService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ManagedApacheCassandraServiceProps = {
   name: string;
@@ -21,6 +23,22 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Managed Apache Cassandra');
+      case 'medium':
+        return SubLabel('Managed Apache Cassandra');
+      default:
+        return SubLabel('MCS');
+    }
+  }
+  return undefined;
+}
+
 export const ManagedApacheCassandraService: FC<ManagedApacheCassandraServiceProps> = ({
   name,
   children,
@@ -29,7 +47,10 @@ export const ManagedApacheCassandraService: FC<ManagedApacheCassandraServiceProp
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ManagedApacheCassandraService.displayName = 'ManagedApacheCassandraService';
+
+export const MCS = ManagedApacheCassandraService;

--- a/component-libraries/aws/src/components/database/Neptune.tsx
+++ b/component-libraries/aws/src/components/database/Neptune.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type NeptuneProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Neptune');
+      default:
+        return SubLabel('Neptune');
+    }
+  }
+  return undefined;
+}
+
 export const Neptune: FC<NeptuneProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Neptune.displayName = 'Neptune';

--- a/component-libraries/aws/src/components/database/QuantumLedgerDatabase.tsx
+++ b/component-libraries/aws/src/components/database/QuantumLedgerDatabase.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type QuantumLedgerDatabaseCategory = 'blockchain' | 'database';
 
@@ -24,6 +26,22 @@ function useIcon(category: QuantumLedgerDatabaseCategory): { path: string; size:
   }, [category]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Quantum Ledger Database');
+      case 'medium':
+        return SubLabel('Quantum Ledger Database');
+      default:
+        return SubLabel('QLDB');
+    }
+  }
+  return undefined;
+}
+
 export const QuantumLedgerDatabase: FC<QuantumLedgerDatabaseProps> = ({
   category = 'database',
   name,
@@ -33,7 +51,10 @@ export const QuantumLedgerDatabase: FC<QuantumLedgerDatabaseProps> = ({
   useAssertProvider();
   const icon = useIcon(category);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 QuantumLedgerDatabase.displayName = 'QuantumLedgerDatabase';
+
+export const QLDB = QuantumLedgerDatabase;

--- a/component-libraries/aws/src/components/database/RDS.tsx
+++ b/component-libraries/aws/src/components/database/RDS.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type RDSType =
   | 'Aurora'
@@ -75,11 +77,28 @@ export type RDSProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Relational Database Service');
+      case 'medium':
+        return SubLabel('Relational Database Service');
+      default:
+        return SubLabel('RDS');
+    }
+  }
+  return undefined;
+}
+
 export const RDS: FC<RDSProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 RDS.displayName = 'RDS';

--- a/component-libraries/aws/src/components/database/Redshift.tsx
+++ b/component-libraries/aws/src/components/database/Redshift.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type RedshiftCategory = 'analytics' | 'database';
 export type RedshiftType = 'Dense compute node' | 'Dense storage node';
@@ -32,11 +34,26 @@ function useIcon(category: RedshiftCategory, type?: RedshiftType): { path: strin
   }, [category, type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Redshift');
+      default:
+        return SubLabel('Redshift');
+    }
+  }
+  return undefined;
+}
+
 export const Redshift: FC<RedshiftProps> = ({ category = 'database', type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(category, type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Redshift.displayName = 'Redshift';

--- a/component-libraries/aws/src/components/database/Timestream.tsx
+++ b/component-libraries/aws/src/components/database/Timestream.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type TimestreamProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Timestream');
+      default:
+        return SubLabel('Timestream');
+    }
+  }
+  return undefined;
+}
+
 export const Timestream: FC<TimestreamProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Timestream.displayName = 'Timestream';

--- a/component-libraries/aws/src/components/developer-tools/Cloud9.tsx
+++ b/component-libraries/aws/src/components/developer-tools/Cloud9.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type Cloud9Type = 'Instance';
 
@@ -29,11 +31,26 @@ export type Cloud9Props = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Cloud9');
+      default:
+        return SubLabel('Cloud9');
+    }
+  }
+  return undefined;
+}
+
 export const Cloud9: FC<Cloud9Props> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Cloud9.displayName = 'Cloud9';

--- a/component-libraries/aws/src/components/developer-tools/CloudDevelopmentKit.tsx
+++ b/component-libraries/aws/src/components/developer-tools/CloudDevelopmentKit.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudDevelopmentKitProps = {
   name: string;
@@ -21,11 +23,30 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Cloud Development Kit');
+      case 'medium':
+        return SubLabel('Cloud Development Kit');
+      default:
+        return SubLabel('CDK');
+    }
+  }
+  return undefined;
+}
+
 export const CloudDevelopmentKit: FC<CloudDevelopmentKitProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CloudDevelopmentKit.displayName = 'CloudDevelopmentKit';
+
+export const CDK = CloudDevelopmentKit;

--- a/component-libraries/aws/src/components/developer-tools/CodeBuild.tsx
+++ b/component-libraries/aws/src/components/developer-tools/CodeBuild.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CodeBuildProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS CodeBuild');
+      default:
+        return SubLabel('CodeBuild');
+    }
+  }
+  return undefined;
+}
+
 export const CodeBuild: FC<CodeBuildProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CodeBuild.displayName = 'CodeBuild';

--- a/component-libraries/aws/src/components/developer-tools/CodeCommit.tsx
+++ b/component-libraries/aws/src/components/developer-tools/CodeCommit.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CodeCommitProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS CodeCommit');
+      default:
+        return SubLabel('CodeCommit');
+    }
+  }
+  return undefined;
+}
+
 export const CodeCommit: FC<CodeCommitProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CodeCommit.displayName = 'CodeCommit';

--- a/component-libraries/aws/src/components/developer-tools/CodeDeploy.tsx
+++ b/component-libraries/aws/src/components/developer-tools/CodeDeploy.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CodeDeployProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS CodeDeploy');
+      default:
+        return SubLabel('CodeDeploy');
+    }
+  }
+  return undefined;
+}
+
 export const CodeDeploy: FC<CodeDeployProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CodeDeploy.displayName = 'CodeDeploy';

--- a/component-libraries/aws/src/components/developer-tools/CodePipeline.tsx
+++ b/component-libraries/aws/src/components/developer-tools/CodePipeline.tsx
@@ -1,8 +1,11 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useMemo, ReactElement } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CodePipelineProps = {
   name: string;
@@ -21,11 +24,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS CodePipeline');
+      default:
+        return SubLabel('CodePipeline');
+    }
+  }
+  return undefined;
+}
+
 export const CodePipeline: FC<CodePipelineProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CodePipeline.displayName = 'CodePipeline';

--- a/component-libraries/aws/src/components/developer-tools/CodeStar.tsx
+++ b/component-libraries/aws/src/components/developer-tools/CodeStar.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CodeStarProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS CodeStar');
+      default:
+        return SubLabel('CodeStar');
+    }
+  }
+  return undefined;
+}
+
 export const CodeStar: FC<CodeStarProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CodeStar.displayName = 'CodeStar';

--- a/component-libraries/aws/src/components/developer-tools/CommandLineInterface.tsx
+++ b/component-libraries/aws/src/components/developer-tools/CommandLineInterface.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CommandLineInterfaceCategory = 'developer-tools' | 'management-governance';
 
@@ -24,6 +26,22 @@ function useIcon(category: CommandLineInterfaceCategory): { path: string; size: 
   }, [category]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Command Line Interface');
+      case 'medium':
+        return SubLabel('Command Line Interface');
+      default:
+        return SubLabel('CLI');
+    }
+  }
+  return undefined;
+}
+
 export const CommandLineInterface: FC<CommandLineInterfaceProps> = ({
   name,
   category = 'management-governance',
@@ -33,7 +51,10 @@ export const CommandLineInterface: FC<CommandLineInterfaceProps> = ({
   useAssertProvider();
   const icon = useIcon(category);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CommandLineInterface.displayName = 'CommandLineInterface';
+
+export const CLI = CommandLineInterface;

--- a/component-libraries/aws/src/components/developer-tools/DeveloperTools.tsx
+++ b/component-libraries/aws/src/components/developer-tools/DeveloperTools.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DeveloperToolsProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Developer Tools on AWS');
+      default:
+        return SubLabel('Developer Tools');
+    }
+  }
+  return undefined;
+}
+
 export const DeveloperTools: FC<DeveloperToolsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DeveloperTools.displayName = 'DeveloperTools';

--- a/component-libraries/aws/src/components/developer-tools/ToolsAndSDKs.tsx
+++ b/component-libraries/aws/src/components/developer-tools/ToolsAndSDKs.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ToolsAndSDKsProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Tools & SDKs');
+  }
+  return undefined;
+}
+
 export const ToolsAndSDKs: FC<ToolsAndSDKsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ToolsAndSDKs.displayName = 'ToolsAndSDKs';

--- a/component-libraries/aws/src/components/developer-tools/XRay.tsx
+++ b/component-libraries/aws/src/components/developer-tools/XRay.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type XRayProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS X-Ray');
+      default:
+        return SubLabel('X-Ray');
+    }
+  }
+  return undefined;
+}
+
 export const XRay: FC<XRayProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 XRay.displayName = 'XRay';

--- a/component-libraries/aws/src/components/end-user-computing/AppStream2.tsx
+++ b/component-libraries/aws/src/components/end-user-computing/AppStream2.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AppStream2Props = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon AppStream 2.0');
+      default:
+        return SubLabel('AppStream 2.0');
+    }
+  }
+  return undefined;
+}
+
 export const AppStream2: FC<AppStream2Props> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 AppStream2.displayName = 'AppStream2';

--- a/component-libraries/aws/src/components/end-user-computing/EndUserComputing.tsx
+++ b/component-libraries/aws/src/components/end-user-computing/EndUserComputing.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type EndUserComputingProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('End User Computing');
+  }
+  return undefined;
+}
+
 export const EndUserComputing: FC<EndUserComputingProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 EndUserComputing.displayName = 'EndUserComputing';

--- a/component-libraries/aws/src/components/end-user-computing/WorkDocs.tsx
+++ b/component-libraries/aws/src/components/end-user-computing/WorkDocs.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type WorkDocsProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon WorkDocs');
+      default:
+        return SubLabel('WorkDocs');
+    }
+  }
+  return undefined;
+}
+
 export const WorkDocs: FC<WorkDocsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 WorkDocs.displayName = 'WorkDocs';

--- a/component-libraries/aws/src/components/end-user-computing/WorkLink.tsx
+++ b/component-libraries/aws/src/components/end-user-computing/WorkLink.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type WorkLinkProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon WorkLink');
+      default:
+        return SubLabel('WorkLink');
+    }
+  }
+  return undefined;
+}
+
 export const WorkLink: FC<WorkLinkProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 WorkLink.displayName = 'WorkLink';

--- a/component-libraries/aws/src/components/end-user-computing/WorkSpaces.tsx
+++ b/component-libraries/aws/src/components/end-user-computing/WorkSpaces.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type WorkSpacesProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon WorkSpaces');
+      default:
+        return SubLabel('WorkSpaces');
+    }
+  }
+  return undefined;
+}
+
 export const WorkSpaces: FC<WorkSpacesProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 WorkSpaces.displayName = 'WorkSpaces';

--- a/component-libraries/aws/src/components/game-tech/GameLift.tsx
+++ b/component-libraries/aws/src/components/game-tech/GameLift.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type GameLiftProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon GameLift');
+      default:
+        return SubLabel('GameLift');
+    }
+  }
+  return undefined;
+}
+
 export const GameLift: FC<GameLiftProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 GameLift.displayName = 'GameLift';

--- a/component-libraries/aws/src/components/game-tech/GameTech.tsx
+++ b/component-libraries/aws/src/components/game-tech/GameTech.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type GameTechProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Game Tech');
+  }
+  return undefined;
+}
+
 export const GameTech: FC<GameTechProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 GameTech.displayName = 'GameTech';

--- a/component-libraries/aws/src/components/groups/AWS.tsx
+++ b/component-libraries/aws/src/components/groups/AWS.tsx
@@ -3,7 +3,9 @@ import { Provider, EdgeStyleBuilder, BuildEdgeStyle } from '@rediagram/cdk';
 import { Subgraph, DOT } from '@ts-graphviz/react';
 import { EdgeAttributes } from 'ts-graphviz';
 import { resolveAsset } from '../../assets';
-import { StyleOption } from '../../types';
+import { AWSContext, StyleOption } from '../../types';
+import { Context } from '../../contexts/Context';
+import { useAWSContext } from '../../hooks/context';
 
 const icon = resolveAsset('groups/aws.png');
 
@@ -100,41 +102,47 @@ function useID(name: string): string {
 
 export type AWSProps = {
   title?: string;
-};
+} & AWSContext;
 
-export const AWS: FC<AWSProps> = ({ title, children }) => {
+export const AWS: FC<AWSProps> = ({ title, children, ...context }) => {
+  const prevContext = useAWSContext();
   return (
     <Provider name="aws">
-      <Subgraph
-        id={useID('cluster_aws')}
-        fontsize="12"
-        labelloc="t"
-        labeljust="l"
-        color="#232F3D"
-        margin="15"
-        label={
-          <DOT.TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0">
-            <DOT.TR>
-              <DOT.TD WIDTH="25" HEIGHT="25" FIXEDSIZE>
-                <DOT.IMG SRC={icon} />
-              </DOT.TD>
-              <DOT.TD>{title ?? 'AWS Cloud'}</DOT.TD>
-            </DOT.TR>
-          </DOT.TABLE>
-        }
-      >
-        <EdgeStyleBuilder build={buildStyle}>{children}</EdgeStyleBuilder>
-      </Subgraph>
+      <Context.Provider value={{ ...prevContext, ...context }}>
+        <Subgraph
+          id={useID('cluster_aws')}
+          fontsize="12"
+          labelloc="t"
+          labeljust="l"
+          color="#232F3D"
+          margin="15"
+          label={
+            <DOT.TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0">
+              <DOT.TR>
+                <DOT.TD WIDTH="25" HEIGHT="25" FIXEDSIZE>
+                  <DOT.IMG SRC={icon} />
+                </DOT.TD>
+                <DOT.TD>{title ?? 'AWS Cloud'}</DOT.TD>
+              </DOT.TR>
+            </DOT.TABLE>
+          }
+        >
+          <EdgeStyleBuilder build={buildStyle}>{children}</EdgeStyleBuilder>
+        </Subgraph>
+      </Context.Provider>
     </Provider>
   );
 };
 
-export const InvizAWS: FC = ({ children }) => {
+export const InvizAWS: FC<AWSContext> = ({ children, ...context }) => {
+  const prevContext = useAWSContext();
   return (
     <Provider name="aws">
-      <Subgraph id={useID('aws')} fontsize="12" color="#232F3D">
-        <EdgeStyleBuilder build={buildStyle}>{children}</EdgeStyleBuilder>
-      </Subgraph>
+      <Context.Provider value={{ ...prevContext, ...context }}>
+        <Subgraph id={useID('aws')} fontsize="12" color="#232F3D">
+          <EdgeStyleBuilder build={buildStyle}>{children}</EdgeStyleBuilder>
+        </Subgraph>
+      </Context.Provider>
     </Provider>
   );
 };

--- a/component-libraries/aws/src/components/internet-of-things/DeviceDefender.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/DeviceDefender.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DeviceDefenderType = 'device jobs';
 
@@ -29,11 +31,26 @@ export type DeviceDefenderProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Device Defender');
+      default:
+        return SubLabel('IoT Device Defender');
+    }
+  }
+  return undefined;
+}
+
 export const DeviceDefender: FC<DeviceDefenderProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DeviceDefender.displayName = 'DeviceDefender';

--- a/component-libraries/aws/src/components/internet-of-things/FreeRTOS.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/FreeRTOS.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type FreeRTOSProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('FreeRTOS');
+  }
+  return undefined;
+}
+
 export const FreeRTOS: FC<FreeRTOSProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 FreeRTOS.displayName = 'FreeRTOS';

--- a/component-libraries/aws/src/components/internet-of-things/InternetOfThings.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/InternetOfThings.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type InternetOfThingsProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Internet of Things');
+      default:
+        return SubLabel('IoT');
+    }
+  }
+  return undefined;
+}
+
 export const InternetOfThings: FC<InternetOfThingsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 InternetOfThings.displayName = 'InternetOfThings';

--- a/component-libraries/aws/src/components/internet-of-things/IoTAnalytics.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTAnalytics.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTAnalyticsType = 'Channel' | 'Data set' | 'Pipeline' | 'Notebook' | 'Data store';
 
@@ -37,11 +39,26 @@ export type IoTAnalyticsProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Analytics');
+      default:
+        return SubLabel('IoT Analytics');
+    }
+  }
+  return undefined;
+}
+
 export const IoTAnalytics: FC<IoTAnalyticsProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTAnalytics.displayName = 'IoTAnalytics';

--- a/component-libraries/aws/src/components/internet-of-things/IoTButton.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTButton.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTButtonProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Button');
+      default:
+        return SubLabel('IoT Button');
+    }
+  }
+  return undefined;
+}
+
 export const IoTButton: FC<IoTButtonProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTButton.displayName = 'IoTButton';

--- a/component-libraries/aws/src/components/internet-of-things/IoTCore.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTCore.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTCoreProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Core');
+      default:
+        return SubLabel('IoT Core');
+    }
+  }
+  return undefined;
+}
+
 export const IoTCore: FC<IoTCoreProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTCore.displayName = 'IoTCore';

--- a/component-libraries/aws/src/components/internet-of-things/IoTDeviceManagement.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTDeviceManagement.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTDeviceManagementProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Device Management');
+      default:
+        return SubLabel('IoT Device Management');
+    }
+  }
+  return undefined;
+}
+
 export const IoTDeviceManagement: FC<IoTDeviceManagementProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTDeviceManagement.displayName = 'IoTDeviceManagement';

--- a/component-libraries/aws/src/components/internet-of-things/IoTEvents.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTEvents.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTEventsProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Events');
+      default:
+        return SubLabel('IoT Events');
+    }
+  }
+  return undefined;
+}
+
 export const IoTEvents: FC<IoTEventsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTEvents.displayName = 'IoTEvents';

--- a/component-libraries/aws/src/components/internet-of-things/IoTGreengrass.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTGreengrass.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTGreengrassType = 'Connector';
 
@@ -29,11 +31,26 @@ export type IoTGreengrassProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Greengrass');
+      default:
+        return SubLabel('IoT Greengrass');
+    }
+  }
+  return undefined;
+}
+
 export const IoTGreengrass: FC<IoTGreengrassProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTGreengrass.displayName = 'IoTGreengrass';

--- a/component-libraries/aws/src/components/internet-of-things/IoTResource.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTResource.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTResourceType =
   | 'action'
@@ -101,11 +103,26 @@ export type IoTResourceProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Resource');
+      default:
+        return SubLabel('IoT Resource');
+    }
+  }
+  return undefined;
+}
+
 export const IoTResource: FC<IoTResourceProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTResource.displayName = 'IoTResource';

--- a/component-libraries/aws/src/components/internet-of-things/IoTSiteWise.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTSiteWise.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTSiteWiseProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT SiteWise');
+      default:
+        return SubLabel('IoT SiteWise');
+    }
+  }
+  return undefined;
+}
+
 export const IoTSiteWise: FC<IoTSiteWiseProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTSiteWise.displayName = 'IoTSiteWise';

--- a/component-libraries/aws/src/components/internet-of-things/IoTThing.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTThing.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTThingType =
   | 'bank'
@@ -77,11 +79,26 @@ export type IoTThingProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Thing');
+      default:
+        return SubLabel('IoT Thing');
+    }
+  }
+  return undefined;
+}
+
 export const IoTThing: FC<IoTThingProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTThing.displayName = 'IoTThing';

--- a/component-libraries/aws/src/components/internet-of-things/IoTThingsGraph.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/IoTThingsGraph.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IoTThingsGraphProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT Things Graph');
+      default:
+        return SubLabel('IoT Things Graph');
+    }
+  }
+  return undefined;
+}
+
 export const IoTThingsGraph: FC<IoTThingsGraphProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IoTThingsGraph.displayName = 'IoTThingsGraph';

--- a/component-libraries/aws/src/components/internet-of-things/OneClick.tsx
+++ b/component-libraries/aws/src/components/internet-of-things/OneClick.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type OneClickProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS IoT 1-Click');
+      default:
+        return SubLabel('IoT 1-Click');
+    }
+  }
+  return undefined;
+}
+
 export const OneClick: FC<OneClickProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 OneClick.displayName = 'OneClick';

--- a/component-libraries/aws/src/components/machine-learning/ApacheMXNetOnAWS.tsx
+++ b/component-libraries/aws/src/components/machine-learning/ApacheMXNetOnAWS.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ApacheMXNetOnAWSProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Apache MXNet on AWS');
+      default:
+        return SubLabel('Apache MXNet');
+    }
+  }
+  return undefined;
+}
+
 export const ApacheMXNetOnAWS: FC<ApacheMXNetOnAWSProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ApacheMXNetOnAWS.displayName = 'ApacheMXNetOnAWS';

--- a/component-libraries/aws/src/components/machine-learning/AugmentedAI.tsx
+++ b/component-libraries/aws/src/components/machine-learning/AugmentedAI.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AugmentedAIProps = {
   name: string;
@@ -21,11 +23,30 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Augmented AI');
+      case 'medium':
+        return SubLabel('Amazon A2I');
+      default:
+        return SubLabel('A2I');
+    }
+  }
+  return undefined;
+}
+
 export const AugmentedAI: FC<AugmentedAIProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 AugmentedAI.displayName = 'AugmentedAI';
+
+export const A2I = AugmentedAI;

--- a/component-libraries/aws/src/components/machine-learning/CodeGuru.tsx
+++ b/component-libraries/aws/src/components/machine-learning/CodeGuru.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CodeGuruProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon CodeGuru');
+      default:
+        return SubLabel('CodeGuru');
+    }
+  }
+  return undefined;
+}
+
 export const CodeGuru: FC<CodeGuruProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CodeGuru.displayName = 'CodeGuru';

--- a/component-libraries/aws/src/components/machine-learning/Comprehend.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Comprehend.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ComprehendProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Comprehend');
+      default:
+        return SubLabel('Comprehend');
+    }
+  }
+  return undefined;
+}
+
 export const Comprehend: FC<ComprehendProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Comprehend.displayName = 'Comprehend';

--- a/component-libraries/aws/src/components/machine-learning/DeepComposer.tsx
+++ b/component-libraries/aws/src/components/machine-learning/DeepComposer.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DeepComposerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS DeepComposer');
+      default:
+        return SubLabel('DeepComposer');
+    }
+  }
+  return undefined;
+}
+
 export const DeepComposer: FC<DeepComposerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DeepComposer.displayName = 'DeepComposer';

--- a/component-libraries/aws/src/components/machine-learning/DeepLearningAMIs.tsx
+++ b/component-libraries/aws/src/components/machine-learning/DeepLearningAMIs.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DeepLearningAMIsProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Deep Learning AMIs');
+      default:
+        return SubLabel('Deep Learning AMIs');
+    }
+  }
+  return undefined;
+}
+
 export const DeepLearningAMIs: FC<DeepLearningAMIsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DeepLearningAMIs.displayName = 'DeepLearningAMIs';

--- a/component-libraries/aws/src/components/machine-learning/DeepLearningContainers.tsx
+++ b/component-libraries/aws/src/components/machine-learning/DeepLearningContainers.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DeepLearningContainersProps = {
   name: string;
@@ -21,11 +23,28 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Deep Learning Containers');
+      case 'medium':
+        return SubLabel('Deep Learning Containers');
+      default:
+        return SubLabel('DL Containers');
+    }
+  }
+  return undefined;
+}
+
 export const DeepLearningContainers: FC<DeepLearningContainersProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DeepLearningContainers.displayName = 'DeepLearningContainers';

--- a/component-libraries/aws/src/components/machine-learning/DeepLens.tsx
+++ b/component-libraries/aws/src/components/machine-learning/DeepLens.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DeepLensProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS DeepLens');
+      default:
+        return SubLabel('DeepLens');
+    }
+  }
+  return undefined;
+}
+
 export const DeepLens: FC<DeepLensProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DeepLens.displayName = 'DeepLens';

--- a/component-libraries/aws/src/components/machine-learning/DeepRacer.tsx
+++ b/component-libraries/aws/src/components/machine-learning/DeepRacer.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DeepRacerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS DeepRacer');
+      default:
+        return SubLabel('DeepRacer');
+    }
+  }
+  return undefined;
+}
+
 export const DeepRacer: FC<DeepRacerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DeepRacer.displayName = 'DeepRacer';

--- a/component-libraries/aws/src/components/machine-learning/ElasticInference.tsx
+++ b/component-libraries/aws/src/components/machine-learning/ElasticInference.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElasticInferenceProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Elastic Inference');
+      default:
+        return SubLabel('Elastic Inference');
+    }
+  }
+  return undefined;
+}
+
 export const ElasticInference: FC<ElasticInferenceProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElasticInference.displayName = 'ElasticInference';

--- a/component-libraries/aws/src/components/machine-learning/Forecast.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Forecast.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ForecastProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Forecast');
+      default:
+        return SubLabel('Forecast');
+    }
+  }
+  return undefined;
+}
+
 export const Forecast: FC<ForecastProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Forecast.displayName = 'Forecast';

--- a/component-libraries/aws/src/components/machine-learning/FraudDetector.tsx
+++ b/component-libraries/aws/src/components/machine-learning/FraudDetector.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type FraudDetectorProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Fraud Detector');
+      default:
+        return SubLabel('Fraud Detector');
+    }
+  }
+  return undefined;
+}
+
 export const FraudDetector: FC<FraudDetectorProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 FraudDetector.displayName = 'FraudDetector';

--- a/component-libraries/aws/src/components/machine-learning/Kendra.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Kendra.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type KendraProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Kendra');
+      default:
+        return SubLabel('Kendra');
+    }
+  }
+  return undefined;
+}
+
 export const Kendra: FC<KendraProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Kendra.displayName = 'Kendra';

--- a/component-libraries/aws/src/components/machine-learning/Lex.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Lex.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type LexProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Lex');
+      default:
+        return SubLabel('Lex');
+    }
+  }
+  return undefined;
+}
+
 export const Lex: FC<LexProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Lex.displayName = 'Lex';

--- a/component-libraries/aws/src/components/machine-learning/MachineLearning.tsx
+++ b/component-libraries/aws/src/components/machine-learning/MachineLearning.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type MachineLearningProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Machine Learning');
+  }
+  return undefined;
+}
+
 export const MachineLearning: FC<MachineLearningProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 MachineLearning.displayName = 'MachineLearning';

--- a/component-libraries/aws/src/components/machine-learning/Personalize.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Personalize.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type PersonalizeProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Personalize');
+      default:
+        return SubLabel('Personalize');
+    }
+  }
+  return undefined;
+}
+
 export const Personalize: FC<PersonalizeProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Personalize.displayName = 'Personalize';

--- a/component-libraries/aws/src/components/machine-learning/Polly.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Polly.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type PollyProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Polly');
+      default:
+        return SubLabel('Polly');
+    }
+  }
+  return undefined;
+}
+
 export const Polly: FC<PollyProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Polly.displayName = 'Polly';

--- a/component-libraries/aws/src/components/machine-learning/Rekognition.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Rekognition.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type RekognitionType = 'Image' | 'Video';
 
@@ -31,11 +33,26 @@ export type RekognitionProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Rekognition');
+      default:
+        return SubLabel('Rekognition');
+    }
+  }
+  return undefined;
+}
+
 export const Rekognition: FC<RekognitionProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Rekognition.displayName = 'Rekognition';

--- a/component-libraries/aws/src/components/machine-learning/SageMaker.tsx
+++ b/component-libraries/aws/src/components/machine-learning/SageMaker.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SageMakerType = 'Ground Truth' | 'Notebook' | 'Model' | 'Train';
 
@@ -35,11 +37,26 @@ export type SageMakerProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon SageMaker');
+      default:
+        return SubLabel('SageMaker');
+    }
+  }
+  return undefined;
+}
+
 export const SageMaker: FC<SageMakerProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SageMaker.displayName = 'SageMaker';

--- a/component-libraries/aws/src/components/machine-learning/TensorFlowOnAWS.tsx
+++ b/component-libraries/aws/src/components/machine-learning/TensorFlowOnAWS.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type TensorFlowOnAWSProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('TensorFlow on AWS');
+      default:
+        return SubLabel('TensorFlow');
+    }
+  }
+  return undefined;
+}
+
 export const TensorFlowOnAWS: FC<TensorFlowOnAWSProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 TensorFlowOnAWS.displayName = 'TensorFlowOnAWS';

--- a/component-libraries/aws/src/components/machine-learning/Textract.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Textract.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type TextractProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Textract');
+      default:
+        return SubLabel('Textract');
+    }
+  }
+  return undefined;
+}
+
 export const Textract: FC<TextractProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Textract.displayName = 'Textract';

--- a/component-libraries/aws/src/components/machine-learning/Transcribe.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Transcribe.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type TranscribeProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Transcribe');
+      default:
+        return SubLabel('Transcribe');
+    }
+  }
+  return undefined;
+}
+
 export const Transcribe: FC<TranscribeProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Transcribe.displayName = 'Transcribe';

--- a/component-libraries/aws/src/components/machine-learning/Translate.tsx
+++ b/component-libraries/aws/src/components/machine-learning/Translate.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type TranslateProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Translate');
+      default:
+        return SubLabel('Translate');
+    }
+  }
+  return undefined;
+}
+
 export const Translate: FC<TranslateProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Translate.displayName = 'Translate';

--- a/component-libraries/aws/src/components/management-governance/AWSConfig.tsx
+++ b/component-libraries/aws/src/components/management-governance/AWSConfig.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AWSConfigProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Config');
+      default:
+        return SubLabel('Config');
+    }
+  }
+  return undefined;
+}
+
 export const AWSConfig: FC<AWSConfigProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 AWSConfig.displayName = 'AWSConfig';

--- a/component-libraries/aws/src/components/management-governance/AppConfig.tsx
+++ b/component-libraries/aws/src/components/management-governance/AppConfig.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AppConfigProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS AppConfig');
+      default:
+        return SubLabel('AppConfig');
+    }
+  }
+  return undefined;
+}
+
 export const AppConfig: FC<AppConfigProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 AppConfig.displayName = 'AppConfig';

--- a/component-libraries/aws/src/components/management-governance/AutoScaling.tsx
+++ b/component-libraries/aws/src/components/management-governance/AutoScaling.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AutoScalingProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Auto Scaling');
+      default:
+        return SubLabel('Auto Scaling');
+    }
+  }
+  return undefined;
+}
+
 export const AutoScaling: FC<AutoScalingProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 AutoScaling.displayName = 'AutoScaling';

--- a/component-libraries/aws/src/components/management-governance/CloudFormation.tsx
+++ b/component-libraries/aws/src/components/management-governance/CloudFormation.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudFormationType = 'Change set' | 'Stack' | 'Template';
 
@@ -33,9 +35,24 @@ export type CloudFormationProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS CloudFormation');
+      default:
+        return SubLabel('CloudFormation');
+    }
+  }
+  return undefined;
+}
+
 export const CloudFormation: FC<CloudFormationProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/management-governance/CloudTrail.tsx
+++ b/component-libraries/aws/src/components/management-governance/CloudTrail.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudTrailProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS CloudTrail');
+      default:
+        return SubLabel('CloudTrail');
+    }
+  }
+  return undefined;
+}
+
 export const CloudTrail: FC<CloudTrailProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CloudTrail.displayName = 'CloudTrail';

--- a/component-libraries/aws/src/components/management-governance/CloudWatch.tsx
+++ b/component-libraries/aws/src/components/management-governance/CloudWatch.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudWatchType = 'Alarm' | 'Rule' | 'Event' | 'Time based event';
 
@@ -35,9 +37,24 @@ export type CloudWatchProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon CloudWatch');
+      default:
+        return SubLabel('CloudWatch');
+    }
+  }
+  return undefined;
+}
+
 export const CloudWatch: FC<CloudWatchProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/management-governance/ControlTower.tsx
+++ b/component-libraries/aws/src/components/management-governance/ControlTower.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ControlTowerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Control Tower');
+      default:
+        return SubLabel('Control Tower');
+    }
+  }
+  return undefined;
+}
+
 export const ControlTower: FC<ControlTowerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ControlTower.displayName = 'ControlTower';

--- a/component-libraries/aws/src/components/management-governance/LicenseManager.tsx
+++ b/component-libraries/aws/src/components/management-governance/LicenseManager.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type LicenseManagerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS License Manager');
+      default:
+        return SubLabel('License Manager');
+    }
+  }
+  return undefined;
+}
+
 export const LicenseManager: FC<LicenseManagerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 LicenseManager.displayName = 'LicenseManager';

--- a/component-libraries/aws/src/components/management-governance/ManagedServices.tsx
+++ b/component-libraries/aws/src/components/management-governance/ManagedServices.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 type ManagedServicesCategory = 'customer-enablement' | 'management-governance';
 export type ManagedServicesProps = {
@@ -23,6 +25,20 @@ function useIcon(category: ManagedServicesCategory): { path: string; size: numbe
   }, [category]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Managed Services');
+      default:
+        return SubLabel('Managed Services');
+    }
+  }
+  return undefined;
+}
+
 export const ManagedServices: FC<ManagedServicesProps> = ({
   name,
   category = 'customer-enablement',
@@ -32,7 +48,8 @@ export const ManagedServices: FC<ManagedServicesProps> = ({
   useAssertProvider();
   const icon = useIcon(category);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ManagedServices.displayName = 'ManagedServices';

--- a/component-libraries/aws/src/components/management-governance/ManagementConsole.tsx
+++ b/component-libraries/aws/src/components/management-governance/ManagementConsole.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ManagementConsoleProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Management Console');
+      default:
+        return SubLabel('Management Console');
+    }
+  }
+  return undefined;
+}
+
 export const ManagementConsole: FC<ManagementConsoleProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ManagementConsole.displayName = 'ManagementConsole';

--- a/component-libraries/aws/src/components/management-governance/ManagementGovernance.tsx
+++ b/component-libraries/aws/src/components/management-governance/ManagementGovernance.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ManagementGovernanceProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Management & Governance');
+  }
+  return undefined;
+}
+
 export const ManagementGovernance: FC<ManagementGovernanceProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ManagementGovernance.displayName = 'ManagementGovernance';

--- a/component-libraries/aws/src/components/management-governance/OpsWorks.tsx
+++ b/component-libraries/aws/src/components/management-governance/OpsWorks.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type OpsWorksType =
   | 'Apps'
@@ -51,9 +53,24 @@ export type OpsWorksProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS OpsWorks');
+      default:
+        return SubLabel('OpsWorks');
+    }
+  }
+  return undefined;
+}
+
 export const OpsWorks: FC<OpsWorksProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/management-governance/Organizations.tsx
+++ b/component-libraries/aws/src/components/management-governance/Organizations.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type OrganizationsType = 'Account' | 'Organizational unit';
 
@@ -31,9 +33,24 @@ export type OrganizationsProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Organizations');
+      default:
+        return SubLabel('Organizations');
+    }
+  }
+  return undefined;
+}
+
 export const Organizations: FC<OrganizationsProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/management-governance/PersonalHealthDashboard.tsx
+++ b/component-libraries/aws/src/components/management-governance/PersonalHealthDashboard.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type PersonalHealthDashboardProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Personal Health Dashboard');
+      default:
+        return SubLabel('Personal Health Dashboard');
+    }
+  }
+  return undefined;
+}
+
 export const PersonalHealthDashboard: FC<PersonalHealthDashboardProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 PersonalHealthDashboard.displayName = 'PersonalHealthDashboard';

--- a/component-libraries/aws/src/components/management-governance/ServiceCatalog.tsx
+++ b/component-libraries/aws/src/components/management-governance/ServiceCatalog.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ServiceCatalogProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Service Catalog');
+      default:
+        return SubLabel('Service Catalog');
+    }
+  }
+  return undefined;
+}
+
 export const ServiceCatalog: FC<ServiceCatalogProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ServiceCatalog.displayName = 'ServiceCatalog';

--- a/component-libraries/aws/src/components/management-governance/SystemsManager.tsx
+++ b/component-libraries/aws/src/components/management-governance/SystemsManager.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SystemsManagerType =
   | 'Automation'
@@ -54,9 +56,24 @@ export type SystemsManagerProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Systems Manager');
+      default:
+        return SubLabel('Systems Manager');
+    }
+  }
+  return undefined;
+}
+
 export const SystemsManager: FC<SystemsManagerProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/management-governance/TrustedAdvisor.tsx
+++ b/component-libraries/aws/src/components/management-governance/TrustedAdvisor.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type TrustedAdvisorType =
   | 'Checklist cost'
@@ -42,9 +44,24 @@ export type TrustedAdvisorProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Trusted Advisor');
+      default:
+        return SubLabel('Trusted Advisor');
+    }
+  }
+  return undefined;
+}
+
 export const TrustedAdvisor: FC<TrustedAdvisorProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/management-governance/WellArchitectedTool.tsx
+++ b/component-libraries/aws/src/components/management-governance/WellArchitectedTool.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type WellArchitectedToolProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Well-Architected Tool');
+      default:
+        return SubLabel('Well-Architected Tool');
+    }
+  }
+  return undefined;
+}
+
 export const WellArchitectedTool: FC<WellArchitectedToolProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 WellArchitectedTool.displayName = 'WellArchitectedTool';

--- a/component-libraries/aws/src/components/media-services/ElasticTranscoder.tsx
+++ b/component-libraries/aws/src/components/media-services/ElasticTranscoder.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElasticTranscoderProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Elastic Transcoder');
+      default:
+        return SubLabel('Elastic Transcoder');
+    }
+  }
+  return undefined;
+}
+
 export const ElasticTranscoder: FC<ElasticTranscoderProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElasticTranscoder.displayName = 'ElasticTranscoder';

--- a/component-libraries/aws/src/components/media-services/ElementalConductor.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalConductor.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalConductorProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental Conductor');
+      default:
+        return SubLabel('Elemental Conductor');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalConductor: FC<ElementalConductorProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalConductor.displayName = 'ElementalConductor';

--- a/component-libraries/aws/src/components/media-services/ElementalDelta.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalDelta.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalDeltaProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental Delta');
+      default:
+        return SubLabel('Elemental Delta');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalDelta: FC<ElementalDeltaProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalDelta.displayName = 'ElementalDelta';

--- a/component-libraries/aws/src/components/media-services/ElementalLive.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalLive.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalLiveProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental Live');
+      default:
+        return SubLabel('Elemental Live');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalLive: FC<ElementalLiveProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalLive.displayName = 'ElementalLive';

--- a/component-libraries/aws/src/components/media-services/ElementalMediaConnect.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalMediaConnect.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalMediaConnectProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental MediaConnect');
+      default:
+        return SubLabel('Elemental MediaConnect');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalMediaConnect: FC<ElementalMediaConnectProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalMediaConnect.displayName = 'ElementalMediaConnect';

--- a/component-libraries/aws/src/components/media-services/ElementalMediaConvert.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalMediaConvert.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalMediaConvertProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental MediaConvert');
+      default:
+        return SubLabel('Elemental MediaConvert');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalMediaConvert: FC<ElementalMediaConvertProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalMediaConvert.displayName = 'ElementalMediaConvert';

--- a/component-libraries/aws/src/components/media-services/ElementalMediaLive.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalMediaLive.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalMediaLiveProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental MediaLive');
+      default:
+        return SubLabel('Elemental MediaLive');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalMediaLive: FC<ElementalMediaLiveProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalMediaLive.displayName = 'ElementalMediaLive';

--- a/component-libraries/aws/src/components/media-services/ElementalMediaPackage.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalMediaPackage.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalMediaPackageProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental MediaPackage');
+      default:
+        return SubLabel('Elemental MediaPackage');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalMediaPackage: FC<ElementalMediaPackageProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalMediaPackage.displayName = 'ElementalMediaPackage';

--- a/component-libraries/aws/src/components/media-services/ElementalMediaStore.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalMediaStore.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalMediaStoreProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental MediaStore');
+      default:
+        return SubLabel('Elemental MediaStore');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalMediaStore: FC<ElementalMediaStoreProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalMediaStore.displayName = 'ElementalMediaStore';

--- a/component-libraries/aws/src/components/media-services/ElementalMediaTailor.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalMediaTailor.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalMediaTailorProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental MediaTailor');
+      default:
+        return SubLabel('Elemental MediaTailor');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalMediaTailor: FC<ElementalMediaTailorProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalMediaTailor.displayName = 'ElementalMediaTailor';

--- a/component-libraries/aws/src/components/media-services/ElementalServer.tsx
+++ b/component-libraries/aws/src/components/media-services/ElementalServer.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElementalServerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Elemental Server');
+      default:
+        return SubLabel('Elemental Server');
+    }
+  }
+  return undefined;
+}
+
 export const ElementalServer: FC<ElementalServerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElementalServer.displayName = 'ElementalServer';

--- a/component-libraries/aws/src/components/media-services/KinesisVideoStreams.tsx
+++ b/component-libraries/aws/src/components/media-services/KinesisVideoStreams.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type KinesisVideoStreamsProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Kinesis Video Streams');
+      default:
+        return SubLabel('Kinesis Video Streams');
+    }
+  }
+  return undefined;
+}
+
 export const KinesisVideoStreams: FC<KinesisVideoStreamsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 KinesisVideoStreams.displayName = 'KinesisVideoStreams';

--- a/component-libraries/aws/src/components/media-services/MediaServices.tsx
+++ b/component-libraries/aws/src/components/media-services/MediaServices.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type MediaServicesProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Media Services');
+  }
+  return undefined;
+}
+
 export const MediaServices: FC<MediaServicesProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 MediaServices.displayName = 'MediaServices';

--- a/component-libraries/aws/src/components/migration-transfer/ApplicationDiscoveryService.tsx
+++ b/component-libraries/aws/src/components/migration-transfer/ApplicationDiscoveryService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ApplicationDiscoveryServiceProps = {
   name: string;
@@ -21,6 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Application Discovery Service');
+      default:
+        return SubLabel('Application Discovery Service');
+    }
+  }
+  return undefined;
+}
+
 export const ApplicationDiscoveryService: FC<ApplicationDiscoveryServiceProps> = ({
   name,
   children,
@@ -29,7 +45,8 @@ export const ApplicationDiscoveryService: FC<ApplicationDiscoveryServiceProps> =
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ApplicationDiscoveryService.displayName = 'ApplicationDiscoveryService';

--- a/component-libraries/aws/src/components/migration-transfer/CloudEndureMigration.tsx
+++ b/component-libraries/aws/src/components/migration-transfer/CloudEndureMigration.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudEndureMigrationProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('CloudEndure Migration');
+  }
+  return undefined;
+}
+
 export const CloudEndureMigration: FC<CloudEndureMigrationProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CloudEndureMigration.displayName = 'CloudEndureMigration';

--- a/component-libraries/aws/src/components/migration-transfer/DataSync.tsx
+++ b/component-libraries/aws/src/components/migration-transfer/DataSync.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DataSyncType = 'Agent';
 
@@ -29,9 +31,24 @@ export type DataSyncProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS DataSync');
+      default:
+        return SubLabel('DataSync');
+    }
+  }
+  return undefined;
+}
+
 export const DataSync: FC<DataSyncProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/migration-transfer/MigrationHub.tsx
+++ b/component-libraries/aws/src/components/migration-transfer/MigrationHub.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type MigrationHubProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Migration Hub');
+      default:
+        return SubLabel('Migration Hub');
+    }
+  }
+  return undefined;
+}
+
 export const MigrationHub: FC<MigrationHubProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 MigrationHub.displayName = 'MigrationHub';

--- a/component-libraries/aws/src/components/migration-transfer/MigrationTransfer.tsx
+++ b/component-libraries/aws/src/components/migration-transfer/MigrationTransfer.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type MigrationTransferProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Migration & Transfer');
+  }
+  return undefined;
+}
+
 export const MigrationTransfer: FC<MigrationTransferProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 MigrationTransfer.displayName = 'MigrationTransfer';

--- a/component-libraries/aws/src/components/migration-transfer/ServerMigrationService.tsx
+++ b/component-libraries/aws/src/components/migration-transfer/ServerMigrationService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ServerMigrationServiceProps = {
   name: string;
@@ -21,11 +23,28 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Server Migration Service');
+      default:
+        return SubLabel('Server Migration Service');
+    }
+  }
+  return undefined;
+}
+
 export const ServerMigrationService: FC<ServerMigrationServiceProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ServerMigrationService.displayName = 'ServerMigrationService';
+
+export const SMS = ServerMigrationService;

--- a/component-libraries/aws/src/components/migration-transfer/TransferFamily.tsx
+++ b/component-libraries/aws/src/components/migration-transfer/TransferFamily.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type TransferFamilyType = 'FTPS' | 'SFTP' | 'FTP';
 
@@ -33,9 +35,24 @@ export type TransferFamilyProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Transfer Family');
+      default:
+        return SubLabel('Transfer Family');
+    }
+  }
+  return undefined;
+}
+
 export const TransferFamily: FC<TransferFamilyProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/mobile/Amplify.tsx
+++ b/component-libraries/aws/src/components/mobile/Amplify.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AmplifyProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Amplify');
+      default:
+        return SubLabel('Amplify');
+    }
+  }
+  return undefined;
+}
+
 export const Amplify: FC<AmplifyProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Amplify.displayName = 'Amplify';

--- a/component-libraries/aws/src/components/mobile/AppSync.tsx
+++ b/component-libraries/aws/src/components/mobile/AppSync.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 type AppSyncCategory = 'mobile' | 'application-integration';
 export type AppSyncProps = {
@@ -23,11 +25,26 @@ function useIcon(category: AppSyncCategory): { path: string; size: number } {
   }, [category]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS AppSync');
+      default:
+        return SubLabel('AppSync');
+    }
+  }
+  return undefined;
+}
+
 export const AppSync: FC<AppSyncProps> = ({ category = 'mobile', name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(category);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 AppSync.displayName = 'AppSync';

--- a/component-libraries/aws/src/components/mobile/DeviceFarm.tsx
+++ b/component-libraries/aws/src/components/mobile/DeviceFarm.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DeviceFarmProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Device Farm');
+      default:
+        return SubLabel('Device Farm');
+    }
+  }
+  return undefined;
+}
+
 export const DeviceFarm: FC<DeviceFarmProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DeviceFarm.displayName = 'DeviceFarm';

--- a/component-libraries/aws/src/components/mobile/Mobile.tsx
+++ b/component-libraries/aws/src/components/mobile/Mobile.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type MobileProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Mobile');
+  }
+  return undefined;
+}
+
 export const Mobile: FC<MobileProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Mobile.displayName = 'Mobile';

--- a/component-libraries/aws/src/components/mobile/Pinpoint.tsx
+++ b/component-libraries/aws/src/components/mobile/Pinpoint.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type PinpointCategory = 'customer-engagement' | 'mobile';
 
@@ -24,11 +26,26 @@ function useIcon(category: PinpointCategory): { path: string; size: number } {
   }, [category]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Pinpoint');
+      default:
+        return SubLabel('Pinpoint');
+    }
+  }
+  return undefined;
+}
+
 export const Pinpoint: FC<PinpointProps> = ({ category = 'mobile', name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(category);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Pinpoint.displayName = 'Pinpoint';

--- a/component-libraries/aws/src/components/networking-content-delivery/APIGateway.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/APIGateway.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type APIGatewayCategory = 'networking-content-delivery' | 'mobile';
 
@@ -32,6 +34,20 @@ export type APIGatewayProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon API Gateway');
+      default:
+        return SubLabel('API Gateway');
+    }
+  }
+  return undefined;
+}
+
 export const APIGateway: FC<APIGatewayProps> = ({
   type,
   category = 'networking-content-delivery',
@@ -42,5 +58,6 @@ export const APIGateway: FC<APIGatewayProps> = ({
   useAssertProvider();
   const icon = useIcon(category, type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/networking-content-delivery/AmazonVPC.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/AmazonVPC.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AmazonVPCType =
   | 'Customer gateway'
@@ -66,9 +68,26 @@ export type AmazonVPCProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Virtual Private Cloud');
+      case 'medium':
+        return SubLabel('Amazon VPC');
+      default:
+        return SubLabel('VPC');
+    }
+  }
+  return undefined;
+}
+
 export const AmazonVPC: FC<AmazonVPCProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/networking-content-delivery/AppMesh.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/AppMesh.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type AppMeshProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS App Mesh');
+      default:
+        return SubLabel('App Mesh');
+    }
+  }
+  return undefined;
+}
+
 export const AppMesh: FC<AppMeshProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 AppMesh.displayName = 'AppMesh';

--- a/component-libraries/aws/src/components/networking-content-delivery/ClientVPN.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/ClientVPN.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ClientVPNProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Client VPN');
+      default:
+        return SubLabel('Client VPN');
+    }
+  }
+  return undefined;
+}
+
 export const ClientVPN: FC<ClientVPNProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ClientVPN.displayName = 'ClientVPN';

--- a/component-libraries/aws/src/components/networking-content-delivery/CloudFront.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/CloudFront.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudFrontType = 'Download distribution' | 'Edge location' | 'Streaming distribution';
 
@@ -33,9 +35,24 @@ export type CloudFrontProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon CloudFront');
+      default:
+        return SubLabel('CloudFront');
+    }
+  }
+  return undefined;
+}
+
 export const CloudFront: FC<CloudFrontProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/networking-content-delivery/CloudMap.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/CloudMap.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudMapProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Cloud Map');
+      default:
+        return SubLabel('Cloud Map');
+    }
+  }
+  return undefined;
+}
+
 export const CloudMap: FC<CloudMapProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CloudMap.displayName = 'CloudMap';

--- a/component-libraries/aws/src/components/networking-content-delivery/DirectConnect.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/DirectConnect.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DirectConnectProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Direct Connect');
+      default:
+        return SubLabel('Direct Connect');
+    }
+  }
+  return undefined;
+}
+
 export const DirectConnect: FC<DirectConnectProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DirectConnect.displayName = 'DirectConnect';

--- a/component-libraries/aws/src/components/networking-content-delivery/ElasticLoadBalancing.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/ElasticLoadBalancing.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElasticLoadBalancingType = 'Application load balancer' | 'Classic load balancer' | 'Network load balancer';
 
@@ -33,9 +35,18 @@ export type ElasticLoadBalancingProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Elastic Load Balancing');
+  }
+  return undefined;
+}
+
 export const ElasticLoadBalancing: FC<ElasticLoadBalancingProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/networking-content-delivery/GlobalAccelerator.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/GlobalAccelerator.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type GlobalAcceleratorProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Global Accelerator');
+      default:
+        return SubLabel('Global Accelerator');
+    }
+  }
+  return undefined;
+}
+
 export const GlobalAccelerator: FC<GlobalAcceleratorProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 GlobalAccelerator.displayName = 'GlobalAccelerator';

--- a/component-libraries/aws/src/components/networking-content-delivery/NetworkingContentDelivery.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/NetworkingContentDelivery.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type NetworkingContentDeliveryProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Networking and Content Delivery');
+  }
+  return undefined;
+}
+
 export const NetworkingContentDelivery: FC<NetworkingContentDeliveryProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 NetworkingContentDelivery.displayName = 'NetworkingContentDelivery';

--- a/component-libraries/aws/src/components/networking-content-delivery/PrivateLink.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/PrivateLink.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type PrivateLinkProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS PrivateLink');
+      default:
+        return SubLabel('PrivateLink');
+    }
+  }
+  return undefined;
+}
+
 export const PrivateLink: FC<PrivateLinkProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 PrivateLink.displayName = 'PrivateLink';

--- a/component-libraries/aws/src/components/networking-content-delivery/Route53.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/Route53.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type Route53Type = 'Hosted zone' | 'Route table';
 
@@ -31,9 +33,24 @@ export type Route53Props = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Route 53');
+      default:
+        return SubLabel('Route 53');
+    }
+  }
+  return undefined;
+}
+
 export const Route53: FC<Route53Props> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/networking-content-delivery/SiteToSiteVPN.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/SiteToSiteVPN.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SiteToSiteVPNProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Site-to-Site VPN');
+      default:
+        return SubLabel('Site-to-Site VPN');
+    }
+  }
+  return undefined;
+}
+
 export const SiteToSiteVPN: FC<SiteToSiteVPNProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SiteToSiteVPN.displayName = 'SiteToSiteVPN';

--- a/component-libraries/aws/src/components/networking-content-delivery/TransitGateway.tsx
+++ b/component-libraries/aws/src/components/networking-content-delivery/TransitGateway.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type TransitGatewayProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Transit Gateway');
+      default:
+        return SubLabel('Transit Gateway');
+    }
+  }
+  return undefined;
+}
+
 export const TransitGateway: FC<TransitGatewayProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 TransitGateway.displayName = 'TransitGateway';

--- a/component-libraries/aws/src/components/quantum-technologies/Braket.tsx
+++ b/component-libraries/aws/src/components/quantum-technologies/Braket.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type BraketProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Braket');
+      default:
+        return SubLabel('Braket');
+    }
+  }
+  return undefined;
+}
+
 export const Braket: FC<BraketProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Braket.displayName = 'Braket';

--- a/component-libraries/aws/src/components/quantum-technologies/QuantumTechnologies.tsx
+++ b/component-libraries/aws/src/components/quantum-technologies/QuantumTechnologies.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type QuantumTechnologiesProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Quantum Technologies');
+  }
+  return undefined;
+}
+
 export const QuantumTechnologies: FC<QuantumTechnologiesProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 QuantumTechnologies.displayName = 'QuantumTechnologies';

--- a/component-libraries/aws/src/components/robotics/RoboMaker.tsx
+++ b/component-libraries/aws/src/components/robotics/RoboMaker.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type RoboMakerType = 'Cloud extensions ROS' | 'Development environment' | 'Fleet management' | 'Simulation';
 
@@ -35,9 +37,24 @@ export type RoboMakerProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS RoboMaker');
+      default:
+        return SubLabel('RoboMaker');
+    }
+  }
+  return undefined;
+}
+
 export const RoboMaker: FC<RoboMakerProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/robotics/Robotics.tsx
+++ b/component-libraries/aws/src/components/robotics/Robotics.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type RoboticsProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Robotics');
+  }
+  return undefined;
+}
+
 export const Robotics: FC<RoboticsProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Robotics.displayName = 'Robotics';

--- a/component-libraries/aws/src/components/satellite/GroundStation.tsx
+++ b/component-libraries/aws/src/components/satellite/GroundStation.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type GroundStationProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Ground Station');
+      default:
+        return SubLabel('Ground Station');
+    }
+  }
+  return undefined;
+}
+
 export const GroundStation: FC<GroundStationProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 GroundStation.displayName = 'GroundStation';

--- a/component-libraries/aws/src/components/satellite/Satellite.tsx
+++ b/component-libraries/aws/src/components/satellite/Satellite.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SatelliteProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Satellite');
+  }
+  return undefined;
+}
+
 export const Satellite: FC<SatelliteProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Satellite.displayName = 'Satellite';

--- a/component-libraries/aws/src/components/security-identity-compliance/Artifact.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/Artifact.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ArtifactProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Artifact');
+      default:
+        return SubLabel('Artifact');
+    }
+  }
+  return undefined;
+}
+
 export const Artifact: FC<ArtifactProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Artifact.displayName = 'Artifact';

--- a/component-libraries/aws/src/components/security-identity-compliance/CertificateManager.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/CertificateManager.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CertificateManagerType = 'Certificate authority';
 
@@ -29,9 +31,24 @@ export type CertificateManagerProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Certificate Manager');
+      default:
+        return SubLabel('Certificate Manager');
+    }
+  }
+  return undefined;
+}
+
 export const CertificateManager: FC<CertificateManagerProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/security-identity-compliance/CloudDirectory.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/CloudDirectory.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudDirectoryProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Cloud Directory');
+      default:
+        return SubLabel('Cloud Directory');
+    }
+  }
+  return undefined;
+}
+
 export const CloudDirectory: FC<CloudDirectoryProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CloudDirectory.displayName = 'CloudDirectory';

--- a/component-libraries/aws/src/components/security-identity-compliance/CloudHSM.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/CloudHSM.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudHSMProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS CloudHSM');
+      default:
+        return SubLabel('CloudHSM');
+    }
+  }
+  return undefined;
+}
+
 export const CloudHSM: FC<CloudHSMProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CloudHSM.displayName = 'CloudHSM';

--- a/component-libraries/aws/src/components/security-identity-compliance/Cognito.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/Cognito.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CognitoProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Cognito');
+      default:
+        return SubLabel('Cognito');
+    }
+  }
+  return undefined;
+}
+
 export const Cognito: FC<CognitoProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Cognito.displayName = 'Cognito';

--- a/component-libraries/aws/src/components/security-identity-compliance/Detective.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/Detective.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DetectiveProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Detective');
+      default:
+        return SubLabel('Detective');
+    }
+  }
+  return undefined;
+}
+
 export const Detective: FC<DetectiveProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Detective.displayName = 'Detective';

--- a/component-libraries/aws/src/components/security-identity-compliance/DirectoryService.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/DirectoryService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type DirectoryServiceType = 'Simple AD' | 'AD Connector' | 'AWS Managed Microsoft AD';
 
@@ -33,11 +35,26 @@ function useIcon(type?: DirectoryServiceType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Managed Microsoft Active Directory');
+      default:
+        return SubLabel('AD');
+    }
+  }
+  return undefined;
+}
+
 export const DirectoryService: FC<DirectoryServiceProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 DirectoryService.displayName = 'DirectoryService';

--- a/component-libraries/aws/src/components/security-identity-compliance/FirewallManager.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/FirewallManager.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type FirewallManagerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Firewall Manager');
+      default:
+        return SubLabel('Firewall Manager');
+    }
+  }
+  return undefined;
+}
+
 export const FirewallManager: FC<FirewallManagerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 FirewallManager.displayName = 'FirewallManager';

--- a/component-libraries/aws/src/components/security-identity-compliance/GuardDuty.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/GuardDuty.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type GuardDutyProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon GuardDuty');
+      default:
+        return SubLabel('GuardDuty');
+    }
+  }
+  return undefined;
+}
+
 export const GuardDuty: FC<GuardDutyProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 GuardDuty.displayName = 'GuardDuty';

--- a/component-libraries/aws/src/components/security-identity-compliance/IAM.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/IAM.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type IAMType =
   | 'Add-on'
@@ -57,11 +59,28 @@ function useIcon(type?: IAMType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Identity and Access Management');
+      case 'medium':
+        return SubLabel('Identity and Access Management');
+      default:
+        return SubLabel('IAM');
+    }
+  }
+  return undefined;
+}
+
 export const IAM: FC<IAMProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 IAM.displayName = 'IAM';

--- a/component-libraries/aws/src/components/security-identity-compliance/Inspector.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/Inspector.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type InspectorType = 'Agent';
 
@@ -29,9 +31,24 @@ export type InspectorProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Inspector');
+      default:
+        return SubLabel('Inspector');
+    }
+  }
+  return undefined;
+}
+
 export const Inspector: FC<InspectorProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/security-identity-compliance/KeyManagementService.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/KeyManagementService.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type KeyManagementServiceProps = {
   name: string;
@@ -21,11 +23,30 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Key Management Service');
+      case 'medium':
+        return SubLabel('Key Management Service');
+      default:
+        return SubLabel('KMS');
+    }
+  }
+  return undefined;
+}
+
 export const KeyManagementService: FC<KeyManagementServiceProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 KeyManagementService.displayName = 'KeyManagementService';
+
+export const KMS = KeyManagementService;

--- a/component-libraries/aws/src/components/security-identity-compliance/Macie.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/Macie.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type MacieProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Macie');
+      default:
+        return SubLabel('Macie');
+    }
+  }
+  return undefined;
+}
+
 export const Macie: FC<MacieProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Macie.displayName = 'Macie';

--- a/component-libraries/aws/src/components/security-identity-compliance/SecretsManager.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/SecretsManager.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SecretsManagerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Secrets Manager');
+      default:
+        return SubLabel('Secrets Manager');
+    }
+  }
+  return undefined;
+}
+
 export const SecretsManager: FC<SecretsManagerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SecretsManager.displayName = 'SecretsManager';

--- a/component-libraries/aws/src/components/security-identity-compliance/SecurityHub.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/SecurityHub.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SecurityHubType = 'Finding';
 
@@ -29,9 +31,24 @@ export type SecurityHubProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Security Hub');
+      default:
+        return SubLabel('Security Hub');
+    }
+  }
+  return undefined;
+}
+
 export const SecurityHub: FC<SecurityHubProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/security-identity-compliance/SecurityIdentityCompliance.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/SecurityIdentityCompliance.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SecurityIdentityComplianceProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Security, Identity, & Compliance');
+  }
+  return undefined;
+}
+
 export const SecurityIdentityCompliance: FC<SecurityIdentityComplianceProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SecurityIdentityCompliance.displayName = 'SecurityIdentityCompliance';

--- a/component-libraries/aws/src/components/security-identity-compliance/Shield.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/Shield.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ShieldType = 'Shield Advanced';
 
@@ -29,9 +31,24 @@ export type ShieldProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Shield');
+      default:
+        return SubLabel('Shield');
+    }
+  }
+  return undefined;
+}
+
 export const Shield: FC<ShieldProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/security-identity-compliance/SingleSignOn.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/SingleSignOn.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SingleSignOnProps = {
   name: string;
@@ -21,11 +23,28 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Single Sign-On');
+      case 'medium':
+        return SubLabel('Single Sign-On');
+      default:
+        return SubLabel('SSO');
+    }
+  }
+  return undefined;
+}
+
 export const SingleSignOn: FC<SingleSignOnProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SingleSignOn.displayName = 'SingleSignOn';

--- a/component-libraries/aws/src/components/security-identity-compliance/WAF.tsx
+++ b/component-libraries/aws/src/components/security-identity-compliance/WAF.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type WAFType = 'Filtering rule';
 
@@ -29,9 +31,24 @@ export type WAFProps = {
   name: string;
 } & AWSDependences;
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS WAF');
+      default:
+        return SubLabel('WAF');
+    }
+  }
+  return undefined;
+}
+
 export const WAF: FC<WAFProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };

--- a/component-libraries/aws/src/components/storage/Backup.tsx
+++ b/component-libraries/aws/src/components/storage/Backup.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type BackupProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Backup');
+      default:
+        return SubLabel('Backup');
+    }
+  }
+  return undefined;
+}
+
 export const Backup: FC<BackupProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Backup.displayName = 'Backup';

--- a/component-libraries/aws/src/components/storage/CloudEndureDisasterRecovery.tsx
+++ b/component-libraries/aws/src/components/storage/CloudEndureDisasterRecovery.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type CloudEndureDisasterRecoveryProps = {
   name: string;
@@ -21,6 +23,14 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('CloudEndure Disaster Recovery');
+  }
+  return undefined;
+}
+
 export const CloudEndureDisasterRecovery: FC<CloudEndureDisasterRecoveryProps> = ({
   name,
   children,
@@ -29,7 +39,8 @@ export const CloudEndureDisasterRecovery: FC<CloudEndureDisasterRecoveryProps> =
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 CloudEndureDisasterRecovery.displayName = 'CloudEndureDisasterRecovery';

--- a/component-libraries/aws/src/components/storage/ElasticBlockStore.tsx
+++ b/component-libraries/aws/src/components/storage/ElasticBlockStore.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElasticBlockStoreType = 'Snapshot' | 'Volume' | 'Multiple volumes';
 
@@ -33,11 +35,30 @@ function useIcon(type?: ElasticBlockStoreType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Elastic Block Store');
+      case 'medium':
+        return SubLabel('Elastic Block Store');
+      default:
+        return SubLabel('EBS');
+    }
+  }
+  return undefined;
+}
+
 export const ElasticBlockStore: FC<ElasticBlockStoreProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElasticBlockStore.displayName = 'ElasticBlockStore';
+
+export const EBS = ElasticBlockStore;

--- a/component-libraries/aws/src/components/storage/ElasticFileSystem.tsx
+++ b/component-libraries/aws/src/components/storage/ElasticFileSystem.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type ElasticFileSystemType = 'File system';
 
@@ -29,11 +31,28 @@ function useIcon(type?: ElasticFileSystemType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Elastic File System');
+      case 'medium':
+        return SubLabel('Elastic File System');
+      default:
+        return SubLabel('EFS');
+    }
+  }
+  return undefined;
+}
+
 export const ElasticFileSystem: FC<ElasticFileSystemProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 ElasticFileSystem.displayName = 'ElasticFileSystem';

--- a/component-libraries/aws/src/components/storage/FSx.tsx
+++ b/component-libraries/aws/src/components/storage/FSx.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type FSxProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon FSx');
+      default:
+        return SubLabel('FSx');
+    }
+  }
+  return undefined;
+}
+
 export const FSx: FC<FSxProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 FSx.displayName = 'FSx';

--- a/component-libraries/aws/src/components/storage/FSxForLustre.tsx
+++ b/component-libraries/aws/src/components/storage/FSxForLustre.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type FSxForLustreProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon FSx for Lustre');
+      default:
+        return SubLabel('FSx for Lustre');
+    }
+  }
+  return undefined;
+}
+
 export const FSxForLustre: FC<FSxForLustreProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 FSxForLustre.displayName = 'FSxForLustre';

--- a/component-libraries/aws/src/components/storage/FSxForWindowsFileServer.tsx
+++ b/component-libraries/aws/src/components/storage/FSxForWindowsFileServer.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type FSxForWindowsFileServerProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon FSx for Windows File Server');
+      default:
+        return SubLabel('FSx for Windows File Server');
+    }
+  }
+  return undefined;
+}
+
 export const FSxForWindowsFileServer: FC<FSxForWindowsFileServerProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 FSxForWindowsFileServer.displayName = 'FSxForWindowsFileServer';

--- a/component-libraries/aws/src/components/storage/InfrequentAccessStorageClass.tsx
+++ b/component-libraries/aws/src/components/storage/InfrequentAccessStorageClass.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type InfrequentAccessStorageClassProps = {
   name: string;
@@ -21,6 +23,14 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Infrequent Access Storage Class');
+  }
+  return undefined;
+}
+
 export const InfrequentAccessStorageClass: FC<InfrequentAccessStorageClassProps> = ({
   name,
   children,
@@ -29,7 +39,8 @@ export const InfrequentAccessStorageClass: FC<InfrequentAccessStorageClassProps>
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 InfrequentAccessStorageClass.displayName = 'InfrequentAccessStorageClass';

--- a/component-libraries/aws/src/components/storage/S3.tsx
+++ b/component-libraries/aws/src/components/storage/S3.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type S3Type = 'Bucket with Objects' | 'Bucket' | 'Object';
 
@@ -33,11 +35,26 @@ function useIcon(type?: S3Type): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon Simple Storage Service');
+      default:
+        return SubLabel('S3');
+    }
+  }
+  return undefined;
+}
+
 export const S3: FC<S3Props> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 S3.displayName = 'S3';

--- a/component-libraries/aws/src/components/storage/S3Glacier.tsx
+++ b/component-libraries/aws/src/components/storage/S3Glacier.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type S3GlacierType = 'Vault' | 'Archive';
 
@@ -31,11 +33,26 @@ function useIcon(type?: S3GlacierType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('Amazon S3 Glacier');
+      default:
+        return SubLabel('S3 Glacier');
+    }
+  }
+  return undefined;
+}
+
 export const S3Glacier: FC<S3GlacierProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 S3Glacier.displayName = 'S3Glacier';

--- a/component-libraries/aws/src/components/storage/Snowball.tsx
+++ b/component-libraries/aws/src/components/storage/Snowball.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SnowballType = 'Snowball import-export';
 
@@ -29,11 +31,26 @@ function useIcon(type?: SnowballType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Snowball');
+      default:
+        return SubLabel('Snowball');
+    }
+  }
+  return undefined;
+}
+
 export const Snowball: FC<SnowballProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Snowball.displayName = 'Snowball';

--- a/component-libraries/aws/src/components/storage/SnowballEdge.tsx
+++ b/component-libraries/aws/src/components/storage/SnowballEdge.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SnowballEdgeProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Snowball Edge');
+      default:
+        return SubLabel('Snowball Edge');
+    }
+  }
+  return undefined;
+}
+
 export const SnowballEdge: FC<SnowballEdgeProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 SnowballEdge.displayName = 'SnowballEdge';

--- a/component-libraries/aws/src/components/storage/Snowmobile.tsx
+++ b/component-libraries/aws/src/components/storage/Snowmobile.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type SnowmobileProps = {
   name: string;
@@ -21,11 +23,26 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Snowmobile');
+      default:
+        return SubLabel('Snowmobile');
+    }
+  }
+  return undefined;
+}
+
 export const Snowmobile: FC<SnowmobileProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Snowmobile.displayName = 'Snowmobile';

--- a/component-libraries/aws/src/components/storage/StandardStorageClass.tsx
+++ b/component-libraries/aws/src/components/storage/StandardStorageClass.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type StandardStorageClassProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Standard Storage Class');
+  }
+  return undefined;
+}
+
 export const StandardStorageClass: FC<StandardStorageClassProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 StandardStorageClass.displayName = 'StandardStorageClass';

--- a/component-libraries/aws/src/components/storage/Storage.tsx
+++ b/component-libraries/aws/src/components/storage/Storage.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type StorageProps = {
   name: string;
@@ -21,11 +23,20 @@ function useIcon(): { path: string; size: number } {
   }, []);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    return SubLabel('Storage');
+  }
+  return undefined;
+}
+
 export const Storage: FC<StorageProps> = ({ name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon();
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 Storage.displayName = 'Storage';

--- a/component-libraries/aws/src/components/storage/StorageGateway.tsx
+++ b/component-libraries/aws/src/components/storage/StorageGateway.tsx
@@ -1,8 +1,10 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { IconNode, useLabelText } from '@rediagram/cdk';
 import { resolveAsset } from '../../assets';
 import { useAssertProvider } from '../../hooks/assert-provider';
 import { AWSDependences } from '../../types';
+import { useAWSContext } from '../../hooks/context';
+import { SubLabel } from '../../hooks/service-name';
 
 export type StorageGatewayType =
   | 'Non-cached volume'
@@ -45,11 +47,26 @@ function useIcon(type?: StorageGatewayType): { path: string; size: number } {
   }, [type]);
 }
 
+function useServiceName(): ReactElement | undefined {
+  const { serviceName } = useAWSContext();
+  if (serviceName) {
+    const type = typeof serviceName === 'object' ? serviceName.type : 'short';
+    switch (type) {
+      case 'full':
+        return SubLabel('AWS Storage Gateway');
+      default:
+        return SubLabel('Storage Gateway');
+    }
+  }
+  return undefined;
+}
+
 export const StorageGateway: FC<StorageGatewayProps> = ({ type, name, children, ...dependences }) => {
   useAssertProvider();
   const icon = useIcon(type);
   const label = useLabelText(children, { defaultValue: name, htmlLike: true });
-  return <IconNode name={name} icon={icon} label={label} {...dependences} />;
+  const subLabel = useServiceName();
+  return <IconNode name={name} icon={icon} label={label} subLabel={subLabel} {...dependences} />;
 };
 
 StorageGateway.displayName = 'StorageGateway';

--- a/component-libraries/aws/src/contexts/Context.ts
+++ b/component-libraries/aws/src/contexts/Context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import { AWSContext } from '../types';
+
+export const Context = createContext<AWSContext>({});

--- a/component-libraries/aws/src/hooks/context.ts
+++ b/component-libraries/aws/src/hooks/context.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+import { Context } from '../contexts/Context';
+import { AWSContext } from '../types';
+
+export function useAWSContext(): AWSContext {
+  return useContext(Context);
+}

--- a/component-libraries/aws/src/hooks/service-name.tsx
+++ b/component-libraries/aws/src/hooks/service-name.tsx
@@ -1,0 +1,6 @@
+import React, { ReactElement } from 'react';
+import { DOT } from '@ts-graphviz/react';
+
+export const SubLabel = (label: string): ReactElement => {
+  return <DOT.FONT COLOR="#5A6B86">{label}</DOT.FONT>;
+};

--- a/component-libraries/aws/src/types.ts
+++ b/component-libraries/aws/src/types.ts
@@ -6,3 +6,11 @@ export type StyleOption = {
 };
 
 export type AWSDependences = HasDependences<StyleOption>;
+
+export type AWSContext = {
+  serviceName?:
+    | boolean
+    | {
+        type: 'full' | 'medium' | 'short';
+      };
+};

--- a/packages/cdk/src/components/IconNode.tsx
+++ b/packages/cdk/src/components/IconNode.tsx
@@ -5,11 +5,12 @@ import { HasDependences, Dependences } from './Dependence';
 export type IconNodeProps = {
   icon: { size: number; path: string };
   label?: string | ReactElement | undefined;
+  subLabel?: string | ReactElement | undefined;
   name: string;
 } & HasDependences;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const IconNode: FC<IconNodeProps> = ({ name, icon, label, children, ...dependences }) => {
+export const IconNode: FC<IconNodeProps> = ({ name, subLabel, icon, label, children, ...dependences }) => {
   return (
     <>
       <Node
@@ -30,6 +31,11 @@ export const IconNode: FC<IconNodeProps> = ({ name, icon, label, children, ...de
             <DOT.TR>
               <DOT.TD>{label}</DOT.TD>
             </DOT.TR>
+            {subLabel ? (
+              <DOT.TR>
+                <DOT.TD>{subLabel}</DOT.TD>
+              </DOT.TR>
+            ) : null}
           </DOT.TABLE>
         }
       />


### PR DESCRIPTION
By assigning the serviceName property to the AWS and Inviz AWS components of the `@rediagram/aws` package, we provided a function to automatically display the service names of the components under it.

```tsx
import React from 'react';
import { PNG, Diagram, GeneralIcon } from 'rediagram';
import { AWS, InvizAWS, EC2, Lambda, Region, SecurityGroup, AutoScalingGroup } from '@rediagram/aws';

PNG(
  <Diagram title="My Infra">
    <InvizAWS serviceName>
      <AWS>
        <Region name="Asia Pacific (Tokyo)">
          <AutoScalingGroup>
            <EC2 name="REST API" type="Instance" upstream={['worker4']} />
          </AutoScalingGroup>
          <SecurityGroup>
            <Lambda name="worker4" type="Lambda Function" upstream={['worker5', 'worker6']} />
            <Lambda name="worker5" type="Lambda Function" />
            <Lambda name="worker6" type="Lambda Function" />
          </SecurityGroup>
        </Region>
      </AWS>
      <GeneralIcon name="Browser" type="Client" upstream={['REST API']} />
    </InvizAWS>
  </Diagram>,
);
```

![MyInfra rediagram](https://user-images.githubusercontent.com/35218186/99094760-96245980-2617-11eb-9444-a39352653e7b.png)
