### PR TITLE
fix NodeCI

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [12.x, 14.x, 16.x]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }} on ubuntu-latest
+    - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: setup grapgviz
+    - name: setup graphviz
       uses: ts-graphviz/setup-graphviz@v1
     - name: Install dependencies
       run: yarn --frozen-lockfile --ignore-optional


### PR DESCRIPTION
- Drop support Node 10.x
- Support Node 14.x and 16.x
- Not to run CI on macos and windows
  - This is a provisional measure to increase the development speed.

